### PR TITLE
REST API: generate a valid fallback URI in wp.api.utils.getRootURL.

### DIFF
--- a/src/js/_enqueues/wp/api.js
+++ b/src/js/_enqueues/wp/api.js
@@ -145,7 +145,7 @@
 	wp.api.utils.getRootUrl = function() {
 		return window.location.origin ?
 			window.location.origin + '/' :
-			window.location.protocol + '/' + window.location.host + '/';
+			window.location.protocol + '//' + window.location.host + '/';
 	};
 
 	/**


### PR DESCRIPTION
When window.location.origin isn't set, correctly insert two slashes between the protocol and host when constructing the fallback URL.

props abdullahramzan.
Fixes #44764.