### PR TITLE
Add null check in wp-embed.js

### DIFF
--- a/src/js/_enqueues/wp/embed.js
+++ b/src/js/_enqueues/wp/embed.js
@@ -29,7 +29,7 @@
 
 	window.wp.receiveEmbedMessage = function( e ) {
 		var data = e.data;
-		if ( ! ( data.secret || data.message || data.value ) ) {
+		if ( ! data || ! ( data.secret || data.message || data.value ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Lack of null check in wp-embed.js causes uncaught error to be thrown under certain circumstances.

This patch improves the check to return early when data is `null`.