### PR TITLE
Support nested properties in ?_fields parameter

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -745,13 +745,13 @@ function rest_filter_response_fields( $response, $server, $request ) {
 	$fields_as_keyed = array();
 	foreach ( $fields as $field ) {
 		$parts = explode( '.', $field );
-		$ref = &$fields_as_keyed;
+		$ref   = &$fields_as_keyed;
 		while ( count( $parts ) > 1 ) {
-			$next = array_shift( $parts );
+			$next         = array_shift( $parts );
 			$ref[ $next ] = array();
-			$ref = &$ref[ $next ];
+			$ref          = &$ref[ $next ];
 		}
-		$last = array_shift( $parts );
+		$last         = array_shift( $parts );
 		$ref[ $last ] = true;
 	}
 

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -770,6 +770,41 @@ function rest_filter_response_fields( $response, $server, $request ) {
 }
 
 /**
+ * Given an array of fields to include in a response, some of which may be
+ * `nested.fields`, determine whether the provided field should be included
+ * in the response body.
+ *
+ * If a parent field is passed in, the presence of any nested field within
+ * that parent will cause the method to return `true`. For example "title"
+ * will return true if any of `title`, `title.raw` or `title.rendered` is
+ * provided.
+ *
+ * @since 5.3.0
+ *
+ * @param string $field  A field to test for inclusion in the response body.
+ * @param array  $fields An array of string fields supported by the endpoint.
+ * @return bool Whether to include the field or not.
+ */
+function rest_is_field_included( $field, $fields ) {
+	if ( in_array( $field, $fields, true ) ) {
+		return true;
+	}
+	foreach ( $fields as $accepted_field ) {
+		// Check to see if $field is the parent of any item in $fields.
+		// A field "parent" should be accepted if "parent.child" is accepted.
+		if ( strpos( $accepted_field, "$field." ) === 0 ) {
+			return true;
+		}
+		// Conversely, if "parent" is accepted, all "parent.child" fields should
+		// also be accepted.
+		if ( strpos( $field, "$accepted_field." ) === 0 ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
  * Adds the REST API URL to the WP RSD endpoint.
  *
  * @since 4.4.0

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -739,7 +739,7 @@ function rest_filter_response_fields( $response, $server, $request ) {
 	}
 
 	// Trim off outside whitespace from the comma delimited list.
-	// $fields = array_map( 'trim', $fields );
+	$fields = array_map( 'trim', $fields );
 
 	// Create nested array of accepted field hierarchy.
 	$fields_as_keyed = array();
@@ -755,62 +755,12 @@ function rest_filter_response_fields( $response, $server, $request ) {
 		$ref[ $last ] = true;
 	}
 
-
-	// $fields_as_keyed = array_reduce( $fields, function( $fields_as_keyed, $field ) {
-	// 	$field_parts = explode( '.', $field );
-	// 	if ( count( $field_parts ) === 1 ) {
-	// 		$fields_as_keyed[ trim( $field ) ] = true;
-	// 		return $fields_as_keyed;
-	// 	}
-	// 	for ( $i = 1; $i < count( $field_parts ); $i++ ) {
-	// 		$has_child_field = isset( $field_parts[ $i + 1 ] );
-	// 		$exists_in_keys = isset( $ )
-	// 		if ( isset( $field_parts[ $i + 1 ] ) ) {
-
-	// 		}
-	// 	}
-	// }, array() );
-	// function build_thing( $keys ) {
-	// 	$fields_as_keyed = array();
-	// 	foreach ( $keys as $key ) {
-	// 		$parts = explode( '.', $key );
-	// 		$ref = &$fields_as_keyed;
-	// 		while ( count( $parts ) > 1 ) {
-	// 			$next = array_shift( $parts );
-	// 			$ref[ $next ] = array();
-	// 			$ref = &$ref[ $next ];
-	// 		}
-	// 		$last = array_shift( $parts );
-	// 		$ref[ $last ] = true;
-	// 	}
-	// 	return $result;
-	// }
-	// var_dump( build_thing( [ 'a', 'b.c.d' ] ) );
-
-	// $filter_item = function( $data ) use ( $fields ) {
-	// 	$new_data = array();
-	// 	foreach ( $fields as $field ) {
-	// 		$field_parts = explode( '.', $field );
-	// 		if ( count( $field_parts ) === 1 && isset( $data[ $field_parts[0] ] ) ) {
-	// 			$new_data[ $field_parts[0] ] = $data[ $field_parts[0] ];
-	// 			continue;
-	// 		}
-	// 		if ( isset( $data[ $field_parts[0] ] ) ) {
-	// 			$new_data[ $field_parts[0] ] = $data[ $field_parts[0] ];
-	// 			continue;
-	// 		}
-	// 	}
-	// 	return $new_data;
-	// };
-
 	if ( wp_is_numeric_array( $data ) ) {
 		$new_data = array();
 		foreach ( $data as $item ) {
-			// $new_data[] = $filter_item( $item );
 			$new_data[] = _rest_array_intersect_key_recursive( $item, $fields_as_keyed );
 		}
 	} else {
-		// $new_data = $filter_item( $data );
 		$new_data = _rest_array_intersect_key_recursive( $data, $fields_as_keyed );
 	}
 

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -708,7 +708,7 @@ function _rest_array_intersect_key_recursive( $array1, $array2 ) {
 	$array1 = array_intersect_key( $array1, $array2 );
 	foreach ( $array1 as $key => $value ) {
 		if ( is_array( $value ) && is_array( $array2[ $key ] ) ) {
-			$value = _rest_array_intersect_key_recursive( $value, $array2[ $key ] );
+			$array1[ $key ] = _rest_array_intersect_key_recursive( $value, $array2[ $key ] );
 		}
 	}
 	return $array1;

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -699,16 +699,17 @@ function rest_send_allow_header( $response, $server, $request ) {
 /**
  * Recursively computes the intersection of arrays using keys for comparison.
  *
- * @param   array $array1 The array with master keys to check.
- * @param   array $array2 An array to compare keys against.
- * @return  array associative array containing all the entries of array1 which have keys that are present in array2.
+ * @param  array $array1 The array with master keys to check.
+ * @param  array $array2 An array to compare keys against.
+ *
+ * @return array An associative array containing all the entries of array1 which have keys that are present in all arguments.
  */
-function _rest_array_intersect_keys_recursive( $array1, $array2 ) {
+function _rest_array_intersect_key_recursive( $array1, $array2 ) {
 	$array1 = array_intersect_key( $array1, $array2 );
 	foreach ( $array1 as $key => $value ) {
-			if ( is_array( $value ) && is_array( $array2[ $key ] ) ) {
-					$value = _rest_array_intersect_keys_recursive( $value, $array2[ $key ] );
-			}
+		if ( is_array( $value ) && is_array( $array2[ $key ] ) ) {
+			$value = _rest_array_intersect_key_recursive( $value, $array2[ $key ] );
+		}
 	}
 	return $array1;
 }
@@ -806,11 +807,11 @@ function rest_filter_response_fields( $response, $server, $request ) {
 		$new_data = array();
 		foreach ( $data as $item ) {
 			// $new_data[] = $filter_item( $item );
-			$new_data[] = _rest_array_intersect_keys_recursive( $item, $fields_as_keyed );
+			$new_data[] = _rest_array_intersect_key_recursive( $item, $fields_as_keyed );
 		}
 	} else {
 		// $new_data = $filter_item( $data );
-		$new_data = _rest_array_intersect_keys_recursive( $data, $fields_as_keyed );
+		$new_data = _rest_array_intersect_key_recursive( $data, $fields_as_keyed );
 	}
 
 	$response->set_data( $new_data );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -697,6 +697,23 @@ function rest_send_allow_header( $response, $server, $request ) {
 }
 
 /**
+ * Recursively computes the intersection of arrays using keys for comparison.
+ *
+ * @param   array $array1 The array with master keys to check.
+ * @param   array $array2 An array to compare keys against.
+ * @return  array associative array containing all the entries of array1 which have keys that are present in array2.
+ */
+function _rest_array_intersect_keys_recursive( $array1, $array2 ) {
+	$array1 = array_intersect_key( $array1, $array2 );
+	foreach ( $array1 as $key => $value ) {
+			if ( is_array( $value ) && is_array( $array2[ $key ] ) ) {
+					$value = _rest_array_intersect_keys_recursive( $value, $array2[ $key ] );
+			}
+	}
+	return $array1;
+}
+
+/**
  * Filter the API response to include only a white-listed set of response object fields.
  *
  * @since 4.8.0
@@ -721,17 +738,79 @@ function rest_filter_response_fields( $response, $server, $request ) {
 	}
 
 	// Trim off outside whitespace from the comma delimited list.
-	$fields = array_map( 'trim', $fields );
+	// $fields = array_map( 'trim', $fields );
 
-	$fields_as_keyed = array_combine( $fields, array_fill( 0, count( $fields ), true ) );
+	// Create nested array of accepted field hierarchy.
+	$fields_as_keyed = array();
+	foreach ( $fields as $field ) {
+		$parts = explode( '.', $field );
+		$ref = &$fields_as_keyed;
+		while ( count( $parts ) > 1 ) {
+			$next = array_shift( $parts );
+			$ref[ $next ] = array();
+			$ref = &$ref[ $next ];
+		}
+		$last = array_shift( $parts );
+		$ref[ $last ] = true;
+	}
+
+
+	// $fields_as_keyed = array_reduce( $fields, function( $fields_as_keyed, $field ) {
+	// 	$field_parts = explode( '.', $field );
+	// 	if ( count( $field_parts ) === 1 ) {
+	// 		$fields_as_keyed[ trim( $field ) ] = true;
+	// 		return $fields_as_keyed;
+	// 	}
+	// 	for ( $i = 1; $i < count( $field_parts ); $i++ ) {
+	// 		$has_child_field = isset( $field_parts[ $i + 1 ] );
+	// 		$exists_in_keys = isset( $ )
+	// 		if ( isset( $field_parts[ $i + 1 ] ) ) {
+
+	// 		}
+	// 	}
+	// }, array() );
+	// function build_thing( $keys ) {
+	// 	$fields_as_keyed = array();
+	// 	foreach ( $keys as $key ) {
+	// 		$parts = explode( '.', $key );
+	// 		$ref = &$fields_as_keyed;
+	// 		while ( count( $parts ) > 1 ) {
+	// 			$next = array_shift( $parts );
+	// 			$ref[ $next ] = array();
+	// 			$ref = &$ref[ $next ];
+	// 		}
+	// 		$last = array_shift( $parts );
+	// 		$ref[ $last ] = true;
+	// 	}
+	// 	return $result;
+	// }
+	// var_dump( build_thing( [ 'a', 'b.c.d' ] ) );
+
+	// $filter_item = function( $data ) use ( $fields ) {
+	// 	$new_data = array();
+	// 	foreach ( $fields as $field ) {
+	// 		$field_parts = explode( '.', $field );
+	// 		if ( count( $field_parts ) === 1 && isset( $data[ $field_parts[0] ] ) ) {
+	// 			$new_data[ $field_parts[0] ] = $data[ $field_parts[0] ];
+	// 			continue;
+	// 		}
+	// 		if ( isset( $data[ $field_parts[0] ] ) ) {
+	// 			$new_data[ $field_parts[0] ] = $data[ $field_parts[0] ];
+	// 			continue;
+	// 		}
+	// 	}
+	// 	return $new_data;
+	// };
 
 	if ( wp_is_numeric_array( $data ) ) {
 		$new_data = array();
 		foreach ( $data as $item ) {
-			$new_data[] = array_intersect_key( $item, $fields_as_keyed );
+			// $new_data[] = $filter_item( $item );
+			$new_data[] = _rest_array_intersect_keys_recursive( $item, $fields_as_keyed );
 		}
 	} else {
-		$new_data = array_intersect_key( $data, $fields_as_keyed );
+		// $new_data = $filter_item( $data );
+		$new_data = _rest_array_intersect_keys_recursive( $data, $fields_as_keyed );
 	}
 
 	$response->set_data( $new_data );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
@@ -584,41 +584,6 @@ abstract class WP_REST_Controller {
 	}
 
 	/**
-	 * Given an array of fields to include in the response, some of which may be
-	 * `nested.fields`, determine whether a provided field should be included in
-	 * the response body.
-	 *
-	 * If a parent field is passed in, the presence of any nested field within
-	 * that parent will cause the method to return `true`. For example "title"
-	 * will return true if any of `title`, `title.raw` or `title.rendered` is
-	 * provided.
-	 *
-	 * @since 5.3.0
-	 *
-	 * @param string $field  A field to test for inclusion in the response body.
-	 * @param array  $fields An array of string fields supported by the endpoint.
-	 * @return bool Whether to include the field or not.
-	 */
-	public function is_field_included( $field, $fields ) {
-		if ( in_array( $field, $fields, true ) ) {
-			return true;
-		}
-		foreach ( $fields as $accepted_field ) {
-			// Check to see if $field is the parent of any item in $fields.
-			// A field "parent" should be accepted if "parent.child" is accepted.
-			if ( strpos( $accepted_field, "$field." ) === 0 ) {
-				return true;
-			}
-			// Conversely, if "parent" is accepted, all "parent.child" fields should
-			// also be accepted.
-			if ( strpos( $field, "$accepted_field." ) === 0 ) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
 	 * Retrieves an array of endpoint arguments from the item schema for the controller.
 	 *
 	 * @since 4.7.0

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
@@ -604,6 +604,18 @@ abstract class WP_REST_Controller {
 		if ( in_array( $field, $fields, true ) ) {
 			return true;
 		}
+		foreach ( $fields as $accepted_field ) {
+			// Check to see if $field is the parent of any item in $fields.
+			// A field "parent" should be accepted if "parent.child" is accepted.
+			if ( strpos( $accepted_field, "$field." ) === 0 ) {
+				return true;
+			}
+			// Conversely, if "parent" is accepted, all "parent.child" fields should
+			// also be accepted.
+			if ( strpos( $field, "$accepted_field." ) === 0 ) {
+				return true;
+			}
+		}
 		return false;
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
@@ -581,7 +581,6 @@ abstract class WP_REST_Controller {
 			},
 			array()
 		);
-		// return array_merge( $fields, $requested_fields );
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
@@ -576,8 +576,8 @@ abstract class WP_REST_Controller {
 				// present in the schema.
 				if ( in_array( $nested_fields[0], $fields, true ) ) {
 					$response_fields[] = $field;
-					return $response_fields;
 				}
+				return $response_fields;
 			},
 			array()
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1623,8 +1623,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$post_type_obj = get_post_type_object( $post->post_type );
 		if ( is_post_type_viewable( $post_type_obj ) && $post_type_obj->public ) {
-			$permalink_template_requested = in_array( 'permalink_template', $fields, true );
-			$generated_slug_requested     = in_array( 'generated_slug', $fields, true );
+			$permalink_template_requested = rest_is_field_included( 'permalink_template', $fields );
+			$generated_slug_requested     = rest_is_field_included( 'generated_slug', $fields );
 
 			if ( $permalink_template_requested || $generated_slug_requested ) {
 				if ( ! function_exists( 'get_sample_permalink' ) ) {
@@ -1633,11 +1633,11 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 				$sample_permalink = get_sample_permalink( $post->ID, $post->post_title, '' );
 
-				if ( $permalink_template_requested && rest_is_field_included( 'permalink_template', $fields ) ) {
+				if ( $permalink_template_requested ) {
 					$data['permalink_template'] = $sample_permalink[0];
 				}
 
-				if ( $generated_slug_requested && rest_is_field_included( 'generated_slug', $fields ) ) {
+				if ( $generated_slug_requested ) {
 					$data['generated_slug'] = $sample_permalink[1];
 				}
 			}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1506,12 +1506,15 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		if ( $this->is_field_included( 'title', $fields ) ) {
+			$data['title'] = array();
+		}
+		if ( $this->is_field_included( 'title.raw', $fields ) ) {
+			$data['title']['raw'] = $post->post_title;
+		}
+		if ( $this->is_field_included( 'title.rendered', $fields ) ) {
 			add_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
 
-			$data['title'] = array(
-				'raw'      => $post->post_title,
-				'rendered' => get_the_title( $post->ID ),
-			);
+			$data['title']['rendered'] = get_the_title( $post->ID );
 
 			remove_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
 		}
@@ -1526,13 +1529,20 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		if ( $this->is_field_included( 'content', $fields ) ) {
-			$data['content'] = array(
-				'raw'           => $post->post_content,
-				/** This filter is documented in wp-includes/post-template.php */
-				'rendered'      => post_password_required( $post ) ? '' : apply_filters( 'the_content', $post->post_content ),
-				'protected'     => (bool) $post->post_password,
-				'block_version' => block_version( $post->post_content ),
-			);
+			$data['content'] = array();
+		}
+		if ( $this->is_field_included( 'content.raw', $fields ) ) {
+			$data['content']['raw'] = $post->post_content;
+		}
+		if ( $this->is_field_included( 'content.rendered', $fields ) ) {
+			/** This filter is documented in wp-includes/post-template.php */
+			$data['content']['rendered'] = post_password_required( $post ) ? '' : apply_filters( 'the_content', $post->post_content );
+		}
+		if ( $this->is_field_included( 'content.protected', $fields ) ) {
+			$data['content']['protected'] = (bool) $post->post_password;
+		}
+		if ( $this->is_field_included( 'content.block_version', $fields ) ) {
+			$data['content']['block_version'] = block_version( $post->post_content );
 		}
 
 		if ( $this->is_field_included( 'excerpt', $fields ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1439,15 +1439,15 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Base fields for every post.
 		$data = array();
 
-		if ( $this->is_field_included( 'id', $fields ) ) {
+		if ( rest_is_field_included( 'id', $fields ) ) {
 			$data['id'] = $post->ID;
 		}
 
-		if ( $this->is_field_included( 'date', $fields ) ) {
+		if ( rest_is_field_included( 'date', $fields ) ) {
 			$data['date'] = $this->prepare_date_response( $post->post_date_gmt, $post->post_date );
 		}
 
-		if ( $this->is_field_included( 'date_gmt', $fields ) ) {
+		if ( rest_is_field_included( 'date_gmt', $fields ) ) {
 			// For drafts, `post_date_gmt` may not be set, indicating that the
 			// date of the draft should be updated each time it is saved (see
 			// #38883).  In this case, shim the value based on the `post_date`
@@ -1460,7 +1460,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$data['date_gmt'] = $this->prepare_date_response( $post_date_gmt );
 		}
 
-		if ( $this->is_field_included( 'guid', $fields ) ) {
+		if ( rest_is_field_included( 'guid', $fields ) ) {
 			$data['guid'] = array(
 				/** This filter is documented in wp-includes/post-template.php */
 				'rendered' => apply_filters( 'get_the_guid', $post->guid, $post->ID ),
@@ -1468,11 +1468,11 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			);
 		}
 
-		if ( $this->is_field_included( 'modified', $fields ) ) {
+		if ( rest_is_field_included( 'modified', $fields ) ) {
 			$data['modified'] = $this->prepare_date_response( $post->post_modified_gmt, $post->post_modified );
 		}
 
-		if ( $this->is_field_included( 'modified_gmt', $fields ) ) {
+		if ( rest_is_field_included( 'modified_gmt', $fields ) ) {
 			// For drafts, `post_modified_gmt` may not be set (see
 			// `post_date_gmt` comments above).  In this case, shim the value
 			// based on the `post_modified` field with the site's timezone
@@ -1485,33 +1485,33 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$data['modified_gmt'] = $this->prepare_date_response( $post_modified_gmt );
 		}
 
-		if ( $this->is_field_included( 'password', $fields ) ) {
+		if ( rest_is_field_included( 'password', $fields ) ) {
 			$data['password'] = $post->post_password;
 		}
 
-		if ( $this->is_field_included( 'slug', $fields ) ) {
+		if ( rest_is_field_included( 'slug', $fields ) ) {
 			$data['slug'] = $post->post_name;
 		}
 
-		if ( $this->is_field_included( 'status', $fields ) ) {
+		if ( rest_is_field_included( 'status', $fields ) ) {
 			$data['status'] = $post->post_status;
 		}
 
-		if ( $this->is_field_included( 'type', $fields ) ) {
+		if ( rest_is_field_included( 'type', $fields ) ) {
 			$data['type'] = $post->post_type;
 		}
 
-		if ( $this->is_field_included( 'link', $fields ) ) {
+		if ( rest_is_field_included( 'link', $fields ) ) {
 			$data['link'] = get_permalink( $post->ID );
 		}
 
-		if ( $this->is_field_included( 'title', $fields ) ) {
+		if ( rest_is_field_included( 'title', $fields ) ) {
 			$data['title'] = array();
 		}
-		if ( $this->is_field_included( 'title.raw', $fields ) ) {
+		if ( rest_is_field_included( 'title.raw', $fields ) ) {
 			$data['title']['raw'] = $post->post_title;
 		}
-		if ( $this->is_field_included( 'title.rendered', $fields ) ) {
+		if ( rest_is_field_included( 'title.rendered', $fields ) ) {
 			add_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
 
 			$data['title']['rendered'] = get_the_title( $post->ID );
@@ -1528,24 +1528,24 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$has_password_filter = true;
 		}
 
-		if ( $this->is_field_included( 'content', $fields ) ) {
+		if ( rest_is_field_included( 'content', $fields ) ) {
 			$data['content'] = array();
 		}
-		if ( $this->is_field_included( 'content.raw', $fields ) ) {
+		if ( rest_is_field_included( 'content.raw', $fields ) ) {
 			$data['content']['raw'] = $post->post_content;
 		}
-		if ( $this->is_field_included( 'content.rendered', $fields ) ) {
+		if ( rest_is_field_included( 'content.rendered', $fields ) ) {
 			/** This filter is documented in wp-includes/post-template.php */
 			$data['content']['rendered'] = post_password_required( $post ) ? '' : apply_filters( 'the_content', $post->post_content );
 		}
-		if ( $this->is_field_included( 'content.protected', $fields ) ) {
+		if ( rest_is_field_included( 'content.protected', $fields ) ) {
 			$data['content']['protected'] = (bool) $post->post_password;
 		}
-		if ( $this->is_field_included( 'content.block_version', $fields ) ) {
+		if ( rest_is_field_included( 'content.block_version', $fields ) ) {
 			$data['content']['block_version'] = block_version( $post->post_content );
 		}
 
-		if ( $this->is_field_included( 'excerpt', $fields ) ) {
+		if ( rest_is_field_included( 'excerpt', $fields ) ) {
 			/** This filter is documented in wp-includes/post-template.php */
 			$excerpt         = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) );
 			$data['excerpt'] = array(
@@ -1560,35 +1560,35 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			remove_filter( 'post_password_required', '__return_false' );
 		}
 
-		if ( $this->is_field_included( 'author', $fields ) ) {
+		if ( rest_is_field_included( 'author', $fields ) ) {
 			$data['author'] = (int) $post->post_author;
 		}
 
-		if ( $this->is_field_included( 'featured_media', $fields ) ) {
+		if ( rest_is_field_included( 'featured_media', $fields ) ) {
 			$data['featured_media'] = (int) get_post_thumbnail_id( $post->ID );
 		}
 
-		if ( $this->is_field_included( 'parent', $fields ) ) {
+		if ( rest_is_field_included( 'parent', $fields ) ) {
 			$data['parent'] = (int) $post->post_parent;
 		}
 
-		if ( $this->is_field_included( 'menu_order', $fields ) ) {
+		if ( rest_is_field_included( 'menu_order', $fields ) ) {
 			$data['menu_order'] = (int) $post->menu_order;
 		}
 
-		if ( $this->is_field_included( 'comment_status', $fields ) ) {
+		if ( rest_is_field_included( 'comment_status', $fields ) ) {
 			$data['comment_status'] = $post->comment_status;
 		}
 
-		if ( $this->is_field_included( 'ping_status', $fields ) ) {
+		if ( rest_is_field_included( 'ping_status', $fields ) ) {
 			$data['ping_status'] = $post->ping_status;
 		}
 
-		if ( $this->is_field_included( 'sticky', $fields ) ) {
+		if ( rest_is_field_included( 'sticky', $fields ) ) {
 			$data['sticky'] = is_sticky( $post->ID );
 		}
 
-		if ( $this->is_field_included( 'template', $fields ) ) {
+		if ( rest_is_field_included( 'template', $fields ) ) {
 			$template = get_page_template_slug( $post->ID );
 			if ( $template ) {
 				$data['template'] = $template;
@@ -1597,7 +1597,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( $this->is_field_included( 'format', $fields ) ) {
+		if ( rest_is_field_included( 'format', $fields ) ) {
 			$data['format'] = get_post_format( $post->ID );
 
 			// Fill in blank post format.
@@ -1606,7 +1606,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( $this->is_field_included( 'meta', $fields ) ) {
+		if ( rest_is_field_included( 'meta', $fields ) ) {
 			$data['meta'] = $this->meta->get_value( $post->ID, $request );
 		}
 
@@ -1615,7 +1615,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		foreach ( $taxonomies as $taxonomy ) {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 
-			if ( $this->is_field_included( $base, $fields ) ) {
+			if ( rest_is_field_included( $base, $fields ) ) {
 				$terms         = get_the_terms( $post, $taxonomy->name );
 				$data[ $base ] = $terms ? array_values( wp_list_pluck( $terms, 'term_id' ) ) : array();
 			}
@@ -1633,11 +1633,11 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 				$sample_permalink = get_sample_permalink( $post->ID, $post->post_title, '' );
 
-				if ( $permalink_template_requested && $this->is_field_included( 'permalink_template', $fields ) ) {
+				if ( $permalink_template_requested && rest_is_field_included( 'permalink_template', $fields ) ) {
 					$data['permalink_template'] = $sample_permalink[0];
 				}
 
-				if ( $generated_slug_requested && $this->is_field_included( 'generated_slug', $fields ) ) {
+				if ( $generated_slug_requested && rest_is_field_included( 'generated_slug', $fields ) ) {
 					$data['generated_slug'] = $sample_permalink[1];
 				}
 			}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1439,15 +1439,15 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Base fields for every post.
 		$data = array();
 
-		if ( in_array( 'id', $fields, true ) ) {
+		if ( $this->is_field_included( 'id', $fields ) ) {
 			$data['id'] = $post->ID;
 		}
 
-		if ( in_array( 'date', $fields, true ) ) {
+		if ( $this->is_field_included( 'date', $fields ) ) {
 			$data['date'] = $this->prepare_date_response( $post->post_date_gmt, $post->post_date );
 		}
 
-		if ( in_array( 'date_gmt', $fields, true ) ) {
+		if ( $this->is_field_included( 'date_gmt', $fields ) ) {
 			// For drafts, `post_date_gmt` may not be set, indicating that the
 			// date of the draft should be updated each time it is saved (see
 			// #38883).  In this case, shim the value based on the `post_date`
@@ -1460,7 +1460,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$data['date_gmt'] = $this->prepare_date_response( $post_date_gmt );
 		}
 
-		if ( in_array( 'guid', $fields, true ) ) {
+		if ( $this->is_field_included( 'guid', $fields ) ) {
 			$data['guid'] = array(
 				/** This filter is documented in wp-includes/post-template.php */
 				'rendered' => apply_filters( 'get_the_guid', $post->guid, $post->ID ),
@@ -1468,11 +1468,11 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			);
 		}
 
-		if ( in_array( 'modified', $fields, true ) ) {
+		if ( $this->is_field_included( 'modified', $fields ) ) {
 			$data['modified'] = $this->prepare_date_response( $post->post_modified_gmt, $post->post_modified );
 		}
 
-		if ( in_array( 'modified_gmt', $fields, true ) ) {
+		if ( $this->is_field_included( 'modified_gmt', $fields ) ) {
 			// For drafts, `post_modified_gmt` may not be set (see
 			// `post_date_gmt` comments above).  In this case, shim the value
 			// based on the `post_modified` field with the site's timezone
@@ -1485,27 +1485,27 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$data['modified_gmt'] = $this->prepare_date_response( $post_modified_gmt );
 		}
 
-		if ( in_array( 'password', $fields, true ) ) {
+		if ( $this->is_field_included( 'password', $fields ) ) {
 			$data['password'] = $post->post_password;
 		}
 
-		if ( in_array( 'slug', $fields, true ) ) {
+		if ( $this->is_field_included( 'slug', $fields ) ) {
 			$data['slug'] = $post->post_name;
 		}
 
-		if ( in_array( 'status', $fields, true ) ) {
+		if ( $this->is_field_included( 'status', $fields ) ) {
 			$data['status'] = $post->post_status;
 		}
 
-		if ( in_array( 'type', $fields, true ) ) {
+		if ( $this->is_field_included( 'type', $fields ) ) {
 			$data['type'] = $post->post_type;
 		}
 
-		if ( in_array( 'link', $fields, true ) ) {
+		if ( $this->is_field_included( 'link', $fields ) ) {
 			$data['link'] = get_permalink( $post->ID );
 		}
 
-		if ( in_array( 'title', $fields, true ) ) {
+		if ( $this->is_field_included( 'title', $fields ) ) {
 			add_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
 
 			$data['title'] = array(
@@ -1525,7 +1525,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$has_password_filter = true;
 		}
 
-		if ( in_array( 'content', $fields, true ) ) {
+		if ( $this->is_field_included( 'content', $fields ) ) {
 			$data['content'] = array(
 				'raw'           => $post->post_content,
 				/** This filter is documented in wp-includes/post-template.php */
@@ -1535,7 +1535,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			);
 		}
 
-		if ( in_array( 'excerpt', $fields, true ) ) {
+		if ( $this->is_field_included( 'excerpt', $fields ) ) {
 			/** This filter is documented in wp-includes/post-template.php */
 			$excerpt         = apply_filters( 'the_excerpt', apply_filters( 'get_the_excerpt', $post->post_excerpt, $post ) );
 			$data['excerpt'] = array(
@@ -1550,35 +1550,35 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			remove_filter( 'post_password_required', '__return_false' );
 		}
 
-		if ( in_array( 'author', $fields, true ) ) {
+		if ( $this->is_field_included( 'author', $fields ) ) {
 			$data['author'] = (int) $post->post_author;
 		}
 
-		if ( in_array( 'featured_media', $fields, true ) ) {
+		if ( $this->is_field_included( 'featured_media', $fields ) ) {
 			$data['featured_media'] = (int) get_post_thumbnail_id( $post->ID );
 		}
 
-		if ( in_array( 'parent', $fields, true ) ) {
+		if ( $this->is_field_included( 'parent', $fields ) ) {
 			$data['parent'] = (int) $post->post_parent;
 		}
 
-		if ( in_array( 'menu_order', $fields, true ) ) {
+		if ( $this->is_field_included( 'menu_order', $fields ) ) {
 			$data['menu_order'] = (int) $post->menu_order;
 		}
 
-		if ( in_array( 'comment_status', $fields, true ) ) {
+		if ( $this->is_field_included( 'comment_status', $fields ) ) {
 			$data['comment_status'] = $post->comment_status;
 		}
 
-		if ( in_array( 'ping_status', $fields, true ) ) {
+		if ( $this->is_field_included( 'ping_status', $fields ) ) {
 			$data['ping_status'] = $post->ping_status;
 		}
 
-		if ( in_array( 'sticky', $fields, true ) ) {
+		if ( $this->is_field_included( 'sticky', $fields ) ) {
 			$data['sticky'] = is_sticky( $post->ID );
 		}
 
-		if ( in_array( 'template', $fields, true ) ) {
+		if ( $this->is_field_included( 'template', $fields ) ) {
 			$template = get_page_template_slug( $post->ID );
 			if ( $template ) {
 				$data['template'] = $template;
@@ -1587,7 +1587,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( in_array( 'format', $fields, true ) ) {
+		if ( $this->is_field_included( 'format', $fields ) ) {
 			$data['format'] = get_post_format( $post->ID );
 
 			// Fill in blank post format.
@@ -1596,7 +1596,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( in_array( 'meta', $fields, true ) ) {
+		if ( $this->is_field_included( 'meta', $fields ) ) {
 			$data['meta'] = $this->meta->get_value( $post->ID, $request );
 		}
 
@@ -1605,7 +1605,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		foreach ( $taxonomies as $taxonomy ) {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 
-			if ( in_array( $base, $fields, true ) ) {
+			if ( $this->is_field_included( $base, $fields ) ) {
 				$terms         = get_the_terms( $post, $taxonomy->name );
 				$data[ $base ] = $terms ? array_values( wp_list_pluck( $terms, 'term_id' ) ) : array();
 			}
@@ -1623,11 +1623,11 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 				$sample_permalink = get_sample_permalink( $post->ID, $post->post_title, '' );
 
-				if ( $permalink_template_requested ) {
+				if ( $permalink_template_requested && $this->is_field_included( 'permalink_template', $fields ) ) {
 					$data['permalink_template'] = $sample_permalink[0];
 				}
 
-				if ( $generated_slug_requested ) {
+				if ( $generated_slug_requested && $this->is_field_included( 'generated_slug', $fields ) ) {
 					$data['generated_slug'] = $sample_permalink[1];
 				}
 			}

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -538,7 +538,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 			),
 		) );
 		$request = array(
-			'_fields' => array( 'b.1', 'c', 'd.5' )
+			'_fields' => 'b.1,c,d.5',
 		);
 
 		$response = rest_filter_response_fields( $response, null, $request );

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -521,6 +521,8 @@ class Tests_REST_API extends WP_UnitTestCase {
 
 	/**
 	 * Ensure that nested fields may be whitelisted with request['_fields'].
+	 *
+	 * @ticket 42094
 	 */
 	public function test_rest_filter_response_fields_nested_field_filter() {
 		$response = new WP_REST_Response();
@@ -558,6 +560,9 @@ class Tests_REST_API extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @ticket 42094
+	 */
 	public function test_rest_is_field_included() {
 		$fields = array(
 			'id',

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -525,32 +525,37 @@ class Tests_REST_API extends WP_UnitTestCase {
 	public function test_rest_filter_response_fields_nested_field_filter() {
 		$response = new WP_REST_Response();
 
-		$response->set_data( array(
-			'a' => 0,
-			'b' => array(
-				'1' => 1,
-				'2' => 2,
-			),
-			'c' => 3,
-			'd' => array(
-				'4' => 4,
-				'5' => 5,
-			),
-		) );
+		$response->set_data(
+			array(
+				'a' => 0,
+				'b' => array(
+					'1' => 1,
+					'2' => 2,
+				),
+				'c' => 3,
+				'd' => array(
+					'4' => 4,
+					'5' => 5,
+				),
+			)
+		);
 		$request = array(
 			'_fields' => 'b.1,c,d.5',
 		);
 
 		$response = rest_filter_response_fields( $response, null, $request );
-		$this->assertEquals( array(
-			'b' => array(
-				'1' => 1,
+		$this->assertEquals(
+			array(
+				'b' => array(
+					'1' => 1,
+				),
+				'c' => 3,
+				'd' => array(
+					'5' => 5,
+				),
 			),
-			'c' => 3,
-			'd' => array(
-				'5' => 5,
-			),
-		), $response->get_data() );
+			$response->get_data()
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -558,6 +558,27 @@ class Tests_REST_API extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_rest_is_field_included() {
+		$fields = array(
+			'id',
+			'title',
+			'content.raw',
+			'custom.property',
+		);
+
+		$this->assertTrue( rest_is_field_included( 'id', $fields ) );
+		$this->assertTrue( rest_is_field_included( 'title', $fields ) );
+		$this->assertTrue( rest_is_field_included( 'title.raw', $fields ) );
+		$this->assertTrue( rest_is_field_included( 'title.rendered', $fields ) );
+		$this->assertTrue( rest_is_field_included( 'content', $fields ) );
+		$this->assertTrue( rest_is_field_included( 'content.raw', $fields ) );
+		$this->assertTrue( rest_is_field_included( 'custom.property', $fields ) );
+		$this->assertFalse( rest_is_field_included( 'content.rendered', $fields ) );
+		$this->assertFalse( rest_is_field_included( 'type', $fields ) );
+		$this->assertFalse( rest_is_field_included( 'meta', $fields ) );
+		$this->assertFalse( rest_is_field_included( 'meta.value', $fields ) );
+	}
+
 	/**
 	 * The get_rest_url function should return a URL consistently terminated with a "/",
 	 * whether the blog is configured with pretty permalink support or not.

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -520,6 +520,40 @@ class Tests_REST_API extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure that nested fields may be whitelisted with request['_fields'].
+	 */
+	public function test_rest_filter_response_fields_nested_field_filter() {
+		$response = new WP_REST_Response();
+
+		$response->set_data( array(
+			'a' => 0,
+			'b' => array(
+				'1' => 1,
+				'2' => 2,
+			),
+			'c' => 3,
+			'd' => array(
+				'4' => 4,
+				'5' => 5,
+			),
+		) );
+		$request = array(
+			'_fields' => array( 'b.1', 'c', 'd.5' )
+		);
+
+		$response = rest_filter_response_fields( $response, null, $request );
+		$this->assertEquals( array(
+			'b' => array(
+				'1' => 1,
+			),
+			'c' => 3,
+			'd' => array(
+				'5' => 5,
+			),
+		), $response->get_data() );
+	}
+
+	/**
 	 * The get_rest_url function should return a URL consistently terminated with a "/",
 	 * whether the blog is configured with pretty permalink support or not.
 	 */

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -232,7 +232,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 	public function data_get_fields_for_response() {
 		return array(
 			array(
-				'somestring,someinteger',
+				'somestring,someinteger,someinvalidkey',
 				array(
 					'somestring',
 					'someinteger',

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -343,6 +343,27 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$this->assertGreaterThan( 0, $listener->get_call_count( $method ) );
 	}
 
+	public function test_is_field_included() {
+		$controller = new WP_REST_Test_Controller();
+
+		$fields = array(
+			'id',
+			'title',
+			'content.raw',
+		);
+
+		$this->assertTrue( $controller->is_field_included( 'id', $fields ) );
+		$this->assertTrue( $controller->is_field_included( 'title', $fields ) );
+		$this->assertTrue( $controller->is_field_included( 'title.raw', $fields ) );
+		$this->assertTrue( $controller->is_field_included( 'title.rendered', $fields ) );
+		$this->assertTrue( $controller->is_field_included( 'content', $fields ) );
+		$this->assertTrue( $controller->is_field_included( 'content.raw', $fields ) );
+		$this->assertFalse( $controller->is_field_included( 'content.rendered', $fields ) );
+		$this->assertFalse( $controller->is_field_included( 'type', $fields ) );
+		$this->assertFalse( $controller->is_field_included( 'meta', $fields ) );
+		$this->assertFalse( $controller->is_field_included( 'meta.value', $fields ) );
+	}
+
 	public function test_add_additional_fields_to_object_respects_fields_param() {
 		$controller = new WP_REST_Test_Controller();
 		$request    = new WP_REST_Request( 'GET', '/wp/v2/testroute' );

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -343,29 +343,6 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$this->assertGreaterThan( 0, $listener->get_call_count( $method ) );
 	}
 
-	public function test_is_field_included() {
-		$controller = new WP_REST_Test_Controller();
-
-		$fields = array(
-			'id',
-			'title',
-			'content.raw',
-			'custom.property',
-		);
-
-		$this->assertTrue( $controller->is_field_included( 'id', $fields ) );
-		$this->assertTrue( $controller->is_field_included( 'title', $fields ) );
-		$this->assertTrue( $controller->is_field_included( 'title.raw', $fields ) );
-		$this->assertTrue( $controller->is_field_included( 'title.rendered', $fields ) );
-		$this->assertTrue( $controller->is_field_included( 'content', $fields ) );
-		$this->assertTrue( $controller->is_field_included( 'content.raw', $fields ) );
-		$this->assertTrue( $controller->is_field_included( 'custom.property', $fields ) );
-		$this->assertFalse( $controller->is_field_included( 'content.rendered', $fields ) );
-		$this->assertFalse( $controller->is_field_included( 'type', $fields ) );
-		$this->assertFalse( $controller->is_field_included( 'meta', $fields ) );
-		$this->assertFalse( $controller->is_field_included( 'meta.value', $fields ) );
-	}
-
 	public function test_add_additional_fields_to_object_respects_fields_param() {
 		$controller = new WP_REST_Test_Controller();
 		$request    = new WP_REST_Request( 'GET', '/wp/v2/testroute' );

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -350,6 +350,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 			'id',
 			'title',
 			'content.raw',
+			'custom.property',
 		);
 
 		$this->assertTrue( $controller->is_field_included( 'id', $fields ) );
@@ -358,6 +359,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$this->assertTrue( $controller->is_field_included( 'title.rendered', $fields ) );
 		$this->assertTrue( $controller->is_field_included( 'content', $fields ) );
 		$this->assertTrue( $controller->is_field_included( 'content.raw', $fields ) );
+		$this->assertTrue( $controller->is_field_included( 'custom.property', $fields ) );
 		$this->assertFalse( $controller->is_field_included( 'content.rendered', $fields ) );
 		$this->assertFalse( $controller->is_field_included( 'type', $fields ) );
 		$this->assertFalse( $controller->is_field_included( 'meta', $fields ) );


### PR DESCRIPTION
REST API: Support dot.nested hierarchical properties in _fields query parameter.

Enable clients to opt-in to receipt of one or more specific sub-properties within a response, and not other sub-properties.
Skip potentially expensive filtering and processing for post resources which were explicitly not requested.

Props kadamwhite, TimothyBlynJacobs, dlh.
Fixes [#42094](https://core.trac.wordpress.org/ticket/42094).