### PR TITLE
#42209: REST API: Always return post types list in taxonomies endpoint response as an array.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
@@ -210,7 +210,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 		}
 
 		if ( in_array( 'types', $fields, true ) ) {
-			$data['types'] = $taxonomy->object_type;
+			$data['types'] = array_values( $taxonomy->object_type );
 		}
 
 		if ( in_array( 'show_cloud', $fields, true ) ) {

--- a/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
@@ -195,6 +195,22 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		);
 	}
 
+	public function test_object_types_is_an_array_if_object_type_is_unregistered() {
+
+		register_taxonomy_for_object_type( 'category', 'page' );
+		register_taxonomy_for_object_type( 'category', 'attachment' );
+		unregister_taxonomy_for_object_type( 'category', 'page' );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$types = $response->get_data()['types'];
+		$this->assertArrayHasKey( 0, $types );
+		$this->assertEquals( 'post', $types[0] );
+		$this->assertArrayHasKey( 1, $types );
+		$this->assertEquals( 'attachment', $types[1] );
+	}
+
 	public function test_get_item_schema() {
 		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/taxonomies' );
 		$response   = rest_get_server()->dispatch( $request );


### PR DESCRIPTION
REST API: Always return post types list in taxonomies endpoint response as an array.

Prevents a non-sequential post type array such as `[ 0 => 'post', 2 => 'page' ]` from being improperly converted to an object in the taxonomy endpoint's response JSON.

Props TimothyBlynJacobs, birgire, spectacula.
Fixes #42209.