### PR TITLE
45169: Default scheme to "rest", not "json".

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -411,10 +411,10 @@ function get_rest_url( $blog_id = null, $path = '/', $scheme = 'rest' ) {
  * @since 4.4.0
  *
  * @param string $path   Optional. REST route. Default empty.
- * @param string $scheme Optional. Sanitization scheme. Default 'json'.
+ * @param string $scheme Optional. Sanitization scheme. Default 'rest'.
  * @return string Full URL to the endpoint.
  */
-function rest_url( $path = '', $scheme = 'json' ) {
+function rest_url( $path = '', $scheme = 'rest' ) {
 	return get_rest_url( null, $path, $scheme );
 }
 


### PR DESCRIPTION
REST API: Consistently default URL scheme to "rest", not "json".

The "json" scheme is a holdover from the pre-merge plugin version of the REST API, and was corrected elsewhere in core in [34300]. Only "rest" is officially supported in `set_url_scheme()`.

Props DrewAPicture, rmccue.
Fixes #45169.