### PR TITLE
#43941: Support default values for registered meta

### DIFF
--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -236,7 +236,7 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 				? ' class="current" aria-current="page"'
 				: '';
 			if ( (int) $counts[ $status ] > 0 ) {
-				$label = sprintf( translate_nooped_plural( $label_count, $counts[ $status ] ), number_format_i18n( $counts[ $status ] ) );
+				$label    = sprintf( translate_nooped_plural( $label_count, $counts[ $status ] ), number_format_i18n( $counts[ $status ] ) );
 				$full_url = 'all' === $status ? $url : add_query_arg( 'status', $status, $url );
 
 				$view_links[ $status ] = sprintf(

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -75,12 +75,12 @@ function add_metadata( $meta_type, $object_id, $meta_key, $meta_value, $unique =
 	}
 
 	if ( $unique && $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*) FROM $table WHERE meta_key = %s AND $column = %d",
-				$meta_key,
-				$object_id
-			)
-		) ) {
+		$wpdb->prepare(
+			"SELECT COUNT(*) FROM $table WHERE meta_key = %s AND $column = %d",
+			$meta_key,
+			$object_id
+		)
+	) ) {
 		return false;
 	}
 
@@ -206,9 +206,9 @@ function update_metadata( $meta_type, $object_id, $meta_key, $meta_value, $prev_
 
 	// Compare existing value to new value if no prev value given and the key exists only once.
 	if ( empty( $prev_value ) ) {
-		remove_filter( "default_{$meta_type}_metadata", "filter_default_metadata", 10, 5 );
+		remove_filter( "default_{$meta_type}_metadata", 'filter_default_metadata', 10, 5 );
 		$old_value = get_metadata( $meta_type, $object_id, $meta_key );
-		add_filter( "default_{$meta_type}_metadata", "filter_default_metadata", 10, 5 );
+		add_filter( "default_{$meta_type}_metadata", 'filter_default_metadata', 10, 5 );
 		if ( count( $old_value ) == 1 ) {
 			if ( $old_value[0] === $meta_value ) {
 				return false;
@@ -1192,7 +1192,6 @@ function register_meta( $object_type, $meta_key, $args, $deprecated = null ) {
 		'type'              => 'string',
 		'description'       => '',
 		'single'            => false,
-		'default'           => null,
 		'sanitize_callback' => null,
 		'auth_callback'     => null,
 		'show_in_rest'      => false,
@@ -1268,11 +1267,11 @@ function register_meta( $object_type, $meta_key, $args, $deprecated = null ) {
 	}
 
 	if ( false === $args['single'] && ! wp_is_numeric_array( $args['default'] ) ) {
-		$args['default'] = null;
+		unset( $args['default'] );
 	}
 
-	if ( null !== $args['default'] ) {
-		add_filter( "default_{$object_type}_metadata", "filter_default_metadata", 10, 5 );
+	if ( array_key_exists( 'default', $args ) ) {
+		add_filter( "default_{$object_type}_metadata", 'filter_default_metadata', 10, 5 );
 	}
 
 	// Global registry only contains meta keys registered with the array of arguments added in 4.6.0.

--- a/tests/phpunit/tests/meta/registerMeta.php
+++ b/tests/phpunit/tests/meta/registerMeta.php
@@ -95,7 +95,6 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
-						'default'           => null,
 						'auth_callback'     => '__return_true',
 						'show_in_rest'      => false,
 					),
@@ -120,7 +119,6 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
-						'default'           => null,
 						'auth_callback'     => '__return_true',
 						'show_in_rest'      => false,
 					),
@@ -174,7 +172,6 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 						'type'              => 'string',
 						'description'       => '',
 						'single'            => false,
-						'default'           => null,
 						'sanitize_callback' => array( $this, '_new_sanitize_meta_cb' ),
 						'auth_callback'     => '__return_true',
 						'show_in_rest'      => false,
@@ -343,7 +340,6 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
-						'default'           => null,
 						'auth_callback'     => '__return_true',
 						'show_in_rest'      => false,
 					),
@@ -397,7 +393,6 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
-						'default'           => null,
 						'auth_callback'     => '__return_true',
 						'show_in_rest'      => false,
 					),
@@ -516,7 +511,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 	public function test_get_default_value( $args, $single, $expected ) {
 
 		$object_type = 'post';
-		$meta_key =	'registered_key1';
+		$meta_key    = 'registered_key1';
 		register_meta(
 			$object_type,
 			$meta_key,
@@ -532,21 +527,21 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 
 		// Set value to check default is not being returned by mistake.
 		$meta_value = 'dibble';
-		update_metadata( $object_type, $object_id, $meta_key, $meta_value);
+		update_metadata( $object_type, $object_id, $meta_key, $meta_value );
 		$value = get_metadata( $object_type, $object_id, $meta_key, true );
 		$this->assertSame( $value, $meta_value );
 
 		// Delete meta, make sure the default is returned.
-		delete_metadata( $object_type, $object_id, $meta_key);
+		delete_metadata( $object_type, $object_id, $meta_key );
 		$value = get_metadata( $object_type, $object_id, $meta_key, $single );
 		$this->assertSame( $value, $expected );
 
 		// Set other meta key, to make sure other keys are not effects.
 		$meta_value = 'hibble';
-		$meta_key = 'unregistered_key1';
-		$value = get_metadata( $object_type, $object_id, $meta_key, true );
+		$meta_key   = 'unregistered_key1';
+		$value      = get_metadata( $object_type, $object_id, $meta_key, true );
 		$this->assertSame( $value, '' );
-		update_metadata( $object_type, $object_id, $meta_key, $meta_value);
+		update_metadata( $object_type, $object_id, $meta_key, $meta_value );
 		$value = get_metadata( $object_type, $object_id, $meta_key, true );
 		$this->assertSame( $value, $meta_value );
 
@@ -563,84 +558,140 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 	public function data_get_default_data() {
 		return array(
 			array(
-				array( 'single' => true, 'default' => 'wibble' ),
+				array(
+					'single'  => true,
+					'default' => 'wibble',
+				),
 				true,
-				'wibble'
+				'wibble',
 			),
 			array(
-				array( 'single' => true, 'default' => 'wibble' ),
+				array(
+					'single'  => true,
+					'default' => 'wibble',
+				),
 				false,
-				array( 'wibble' )
+				array( 'wibble' ),
 			),
 			array(
-				array( 'single' => true, 'default' => array( 'wibble' ) ),
+				array(
+					'single'  => true,
+					'default' => array( 'wibble' ),
+				),
 				true,
-				array( 'wibble' )
+				array( 'wibble' ),
 			),
 			array(
-				array( 'single' => true, 'default' => array( 'wibble' ) ),
+				array(
+					'single'  => true,
+					'default' => array( 'wibble' ),
+				),
 				false,
-				array( array( 'wibble' ) )
+				array( array( 'wibble' ) ),
 			),
 			array(
-				array( 'single' => false, 'default' => 'wibble' ),
+				array(
+					'single'  => false,
+					'default' => 'wibble',
+				),
 				true,
-				''
+				'',
 			),
 			array(
-				array( 'single' => false, 'default' => 'wibble' ),
+				array(
+					'single'  => false,
+					'default' => 'wibble',
+				),
 				false,
-				array()
+				array(),
 			),
 			array(
-				array( 'single' => false, 'default' => array( 'wibble' ) ),
+				array(
+					'single'  => false,
+					'default' => array( 'wibble' ),
+				),
 				true,
-				'wibble'
+				'wibble',
 			),
 			array(
-				array( 'single' => false, 'default' => array( 'wibble' ) ),
+				array(
+					'single'  => false,
+					'default' => array( 'wibble' ),
+				),
 				false,
-				array( 'wibble' )
+				array( 'wibble' ),
 			),
 			array(
-				array( 'single' => true, 'object_subtype'=> 'page', 'default' => 'wibble' ),
+				array(
+					'single'         => true,
+					'object_subtype' => 'page',
+					'default'        => 'wibble',
+				),
 				true,
-				'wibble'
+				'wibble',
 			),
 			array(
-				array( 'single' => true, 'object_subtype'=> 'page', 'default' => 'wibble' ),
+				array(
+					'single'         => true,
+					'object_subtype' => 'page',
+					'default'        => 'wibble',
+				),
 				false,
-				array( 'wibble' )
+				array( 'wibble' ),
 			),
 			array(
-				array( 'single' => true, 'object_subtype'=> 'page', 'default' => array( 'wibble' ) ),
+				array(
+					'single'         => true,
+					'object_subtype' => 'page',
+					'default'        => array( 'wibble' ),
+				),
 				true,
-				array( 'wibble' )
+				array( 'wibble' ),
 			),
 			array(
-				array( 'single' => true, 'object_subtype'=> 'page', 'default' => array( 'wibble' ) ),
+				array(
+					'single'         => true,
+					'object_subtype' => 'page',
+					'default'        => array( 'wibble' ),
+				),
 				false,
-				array( array( 'wibble' ) )
+				array( array( 'wibble' ) ),
 			),
 			array(
-				array( 'single' => true, 'object_subtype'=> 'post', 'default' => 'wibble' ),
+				array(
+					'single'         => true,
+					'object_subtype' => 'post',
+					'default'        => 'wibble',
+				),
 				true,
-				''
+				'',
 			),
 			array(
-				array( 'single' => true, 'object_subtype'=> 'post', 'default' => 'wibble' ),
+				array(
+					'single'         => true,
+					'object_subtype' => 'post',
+					'default'        => 'wibble',
+				),
 				false,
-				array()
+				array(),
 			),
 			array(
-				array( 'single' => true, 'object_subtype'=> 'post', 'default' => array( 'wibble' ) ),
+				array(
+					'single'         => true,
+					'object_subtype' => 'post',
+					'default'        => array( 'wibble' ),
+				),
 				true,
-				''
+				'',
 			),
 			array(
-				array( 'single' => true, 'object_subtype'=> 'post', 'default' => array( 'wibble' ) ),
+				array(
+					'single'         => true,
+					'object_subtype' => 'post',
+					'default'        => array( 'wibble' ),
+				),
 				false,
-				array()
+				array(),
 			),
 		);
 	}

--- a/tests/phpunit/tests/meta/registerMeta.php
+++ b/tests/phpunit/tests/meta/registerMeta.php
@@ -95,6 +95,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
+						'default'           => null,
 						'auth_callback'     => '__return_true',
 						'show_in_rest'      => false,
 					),
@@ -119,6 +120,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
+						'default'           => null,
 						'auth_callback'     => '__return_true',
 						'show_in_rest'      => false,
 					),
@@ -172,6 +174,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 						'type'              => 'string',
 						'description'       => '',
 						'single'            => false,
+						'default'           => null,
 						'sanitize_callback' => array( $this, '_new_sanitize_meta_cb' ),
 						'auth_callback'     => '__return_true',
 						'show_in_rest'      => false,
@@ -340,6 +343,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
+						'default'           => null,
 						'auth_callback'     => '__return_true',
 						'show_in_rest'      => false,
 					),
@@ -393,6 +397,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
+						'default'           => null,
 						'auth_callback'     => '__return_true',
 						'show_in_rest'      => false,
 					),
@@ -504,12 +509,140 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 		$this->assertSame( 'even', $subtype_for_4 );
 	}
 
+	/**
+	 * @ticket 43941
+	 * @dataProvider data_get_default_data
+	 */
+	public function test_get_default_value( $args, $single, $expected ) {
+
+		$object_type = 'post';
+		$meta_key =	'registered_key1';
+		register_meta(
+			$object_type,
+			$meta_key,
+			$args
+		);
+
+		$object_property_name = $object_type . '_id';
+		$object_id            = self::$$object_property_name;
+
+		// Check for default value.
+		$value = get_metadata( $object_type, $object_id, $meta_key, $single );
+		$this->assertSame( $value, $expected );
+
+		// Set value to check default is not being returned by mistake.
+		$meta_value = 'dibble';
+		update_metadata( $object_type, $object_id, $meta_key, $meta_value);
+		$value = get_metadata( $object_type, $object_id, $meta_key, true );
+		$this->assertSame( $value, $meta_value );
+
+		// Delete meta, make sure the default is returned.
+		delete_metadata( $object_type, $object_id, $meta_key);
+		$value = get_metadata( $object_type, $object_id, $meta_key, $single );
+		$this->assertSame( $value, $expected );
+
+		// Set other meta key, to make sure other keys are not effects.
+		$meta_value = 'hibble';
+		$meta_key = 'unregistered_key1';
+		$value = get_metadata( $object_type, $object_id, $meta_key, true );
+		$this->assertSame( $value, '' );
+		update_metadata( $object_type, $object_id, $meta_key, $meta_value);
+		$value = get_metadata( $object_type, $object_id, $meta_key, true );
+		$this->assertSame( $value, $meta_value );
+
+	}
+
 	public function filter_get_object_subtype_for_customtype( $subtype, $object_id ) {
 		if ( 1 === ( $object_id % 2 ) ) {
 			return 'odd';
 		}
 
 		return 'even';
+	}
+
+	public function data_get_default_data() {
+		return array(
+			array(
+				array( 'single' => true, 'default' => 'wibble' ),
+				true,
+				'wibble'
+			),
+			array(
+				array( 'single' => true, 'default' => 'wibble' ),
+				false,
+				array( 'wibble' )
+			),
+			array(
+				array( 'single' => true, 'default' => array( 'wibble' ) ),
+				true,
+				array( 'wibble' )
+			),
+			array(
+				array( 'single' => true, 'default' => array( 'wibble' ) ),
+				false,
+				array( array( 'wibble' ) )
+			),
+			array(
+				array( 'single' => false, 'default' => 'wibble' ),
+				true,
+				''
+			),
+			array(
+				array( 'single' => false, 'default' => 'wibble' ),
+				false,
+				array()
+			),
+			array(
+				array( 'single' => false, 'default' => array( 'wibble' ) ),
+				true,
+				'wibble'
+			),
+			array(
+				array( 'single' => false, 'default' => array( 'wibble' ) ),
+				false,
+				array( 'wibble' )
+			),
+			array(
+				array( 'single' => true, 'object_subtype'=> 'page', 'default' => 'wibble' ),
+				true,
+				'wibble'
+			),
+			array(
+				array( 'single' => true, 'object_subtype'=> 'page', 'default' => 'wibble' ),
+				false,
+				array( 'wibble' )
+			),
+			array(
+				array( 'single' => true, 'object_subtype'=> 'page', 'default' => array( 'wibble' ) ),
+				true,
+				array( 'wibble' )
+			),
+			array(
+				array( 'single' => true, 'object_subtype'=> 'page', 'default' => array( 'wibble' ) ),
+				false,
+				array( array( 'wibble' ) )
+			),
+			array(
+				array( 'single' => true, 'object_subtype'=> 'post', 'default' => 'wibble' ),
+				true,
+				''
+			),
+			array(
+				array( 'single' => true, 'object_subtype'=> 'post', 'default' => 'wibble' ),
+				false,
+				array()
+			),
+			array(
+				array( 'single' => true, 'object_subtype'=> 'post', 'default' => array( 'wibble' ) ),
+				true,
+				''
+			),
+			array(
+				array( 'single' => true, 'object_subtype'=> 'post', 'default' => array( 'wibble' ) ),
+				false,
+				array()
+			),
+		);
 	}
 
 	public function data_get_types_and_subtypes() {


### PR DESCRIPTION
Options, Meta APIs: Permit a default value to be specified when registering meta. 

Props spacedmonkey, TimothyBlynJacobs, flixos90, swissspidy.
Fixes #43941.