### PR TITLE
#45677: Introduce WP_Post_Type::get_rest_controller

### DIFF
--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -336,6 +336,16 @@ final class WP_Post_Type {
 	public $rest_controller_class;
 
 	/**
+	 * The controller instance for this post type's REST API endpoints.
+	 *
+	 * Lazily computed. Should be accessed using {@see WP_Post_Type::get_rest_controller()}.
+	 *
+	 * @since 5.3.0
+	 * @var WP_REST_Controller $rest_controller
+	 */
+	private $rest_controller;
+
+	/**
 	 * Constructor.
 	 *
 	 * Will populate object properties from the provided arguments and assign other
@@ -681,5 +691,37 @@ final class WP_Post_Type {
 	 */
 	public function remove_hooks() {
 		remove_action( 'future_' . $this->name, '_future_post_hook', 5 );
+	}
+
+	/**
+	 * Gets the REST API controller for this post type.
+	 *
+	 * Will only instantiate the controller class once per request.
+	 *
+	 * @since 5.3.0
+	 *
+	 * @return WP_REST_Controller|null The controller instance, or null if the post type
+	 *                                 is set not to show in rest.
+	 */
+	public function get_rest_controller() {
+		if ( ! $this->show_in_rest ) {
+			return null;
+		}
+
+		$class = $this->rest_controller_class ? $this->rest_controller_class : WP_REST_Posts_Controller::class;
+
+		if ( ! class_exists( $class ) ) {
+			return null;
+		}
+
+		if ( ! is_subclass_of( $class, WP_REST_Controller::class ) ) {
+			return null;
+		}
+
+		if ( ! $this->rest_controller ) {
+			$this->rest_controller = new $class( $this->name );
+		}
+
+		return $this->rest_controller;
 	}
 }

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -191,26 +191,22 @@ function rest_api_default_filters() {
  * @since 4.7.0
  */
 function create_initial_rest_routes() {
-	foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
-		$class = ! empty( $post_type->rest_controller_class ) ? $post_type->rest_controller_class : 'WP_REST_Posts_Controller';
+	foreach ( get_post_types( array( 'show_in_rest' => true ) ) as $post_type ) {
+		$controller = WP_REST_Posts_Controller::get_for_post_type( $post_type );
 
-		if ( ! class_exists( $class ) ) {
-			continue;
-		}
-		$controller = new $class( $post_type->name );
-		if ( ! is_subclass_of( $controller, 'WP_REST_Controller' ) ) {
+		if ( ! $controller ) {
 			continue;
 		}
 
 		$controller->register_routes();
 
-		if ( post_type_supports( $post_type->name, 'revisions' ) ) {
-			$revisions_controller = new WP_REST_Revisions_Controller( $post_type->name );
+		if ( post_type_supports( $post_type, 'revisions' ) ) {
+			$revisions_controller = new WP_REST_Revisions_Controller( $post_type );
 			$revisions_controller->register_routes();
 		}
 
-		if ( 'attachment' !== $post_type->name ) {
-			$autosaves_controller = new WP_REST_Autosaves_Controller( $post_type->name );
+		if ( 'attachment' !== $post_type ) {
+			$autosaves_controller = new WP_REST_Autosaves_Controller( $post_type );
 			$autosaves_controller->register_routes();
 		}
 	}

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -191,8 +191,8 @@ function rest_api_default_filters() {
  * @since 4.7.0
  */
 function create_initial_rest_routes() {
-	foreach ( get_post_types( array( 'show_in_rest' => true ) ) as $post_type ) {
-		$controller = WP_REST_Posts_Controller::get_for_post_type( $post_type );
+	foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+		$controller = $post_type->get_rest_controller();
 
 		if ( ! $controller ) {
 			continue;
@@ -200,13 +200,13 @@ function create_initial_rest_routes() {
 
 		$controller->register_routes();
 
-		if ( post_type_supports( $post_type, 'revisions' ) ) {
-			$revisions_controller = new WP_REST_Revisions_Controller( $post_type );
+		if ( post_type_supports( $post_type->name, 'revisions' ) ) {
+			$revisions_controller = new WP_REST_Revisions_Controller( $post_type->name );
 			$revisions_controller->register_routes();
 		}
 
-		if ( 'attachment' !== $post_type ) {
-			$autosaves_controller = new WP_REST_Autosaves_Controller( $post_type );
+		if ( 'attachment' !== $post_type->name ) {
+			$autosaves_controller = new WP_REST_Autosaves_Controller( $post_type->name );
 			$autosaves_controller->register_routes();
 		}
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -57,14 +57,14 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	 * @param string $parent_post_type Post type of the parent.
 	 */
 	public function __construct( $parent_post_type ) {
-		$parent_controller = WP_REST_Posts_Controller::get_for_post_type( $parent_post_type );
+		$this->parent_post_type = $parent_post_type;
+		$post_type_object       = get_post_type_object( $parent_post_type );
+		$parent_controller      = $post_type_object->get_rest_controller();
 
 		if ( ! $parent_controller ) {
 			$parent_controller = new WP_REST_Posts_Controller( $parent_post_type );
 		}
 
-		$this->parent_post_type     = $parent_post_type;
-		$post_type_object           = get_post_type_object( $parent_post_type );
 		$this->parent_controller    = $parent_controller;
 		$this->revisions_controller = new WP_REST_Revisions_Controller( $parent_post_type );
 		$this->rest_namespace       = 'wp/v2';

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -57,13 +57,15 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	 * @param string $parent_post_type Post type of the parent.
 	 */
 	public function __construct( $parent_post_type ) {
-		$this->parent_post_type = $parent_post_type;
-		$post_type_object       = get_post_type_object( $parent_post_type );
+		$parent_controller = WP_REST_Posts_Controller::get_for_post_type( $parent_post_type );
 
-		// Ensure that post type-specific controller logic is available.
-		$parent_controller_class = ! empty( $post_type_object->rest_controller_class ) ? $post_type_object->rest_controller_class : 'WP_REST_Posts_Controller';
+		if ( ! $parent_controller ) {
+			$parent_controller = new WP_REST_Posts_Controller( $parent_post_type );
+		}
 
-		$this->parent_controller    = new $parent_controller_class( $post_type_object->name );
+		$this->parent_post_type     = $parent_post_type;
+		$post_type_object           = get_post_type_object( $parent_post_type );
+		$this->parent_controller    = $parent_controller;
 		$this->revisions_controller = new WP_REST_Revisions_Controller( $parent_post_type );
 		$this->rest_namespace       = 'wp/v2';
 		$this->rest_base            = 'autosaves';

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1592,8 +1592,15 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * @return bool Whether post can be read.
 	 */
 	protected function check_read_post_permission( $post, $request ) {
-		$posts_controller = new WP_REST_Posts_Controller( $post->post_type );
-		$post_type        = get_post_type_object( $post->post_type );
+		$posts_controller = WP_REST_Posts_Controller::get_for_post_type( $post->post_type );
+
+		// We need to specifically assert that the posts controller is a WP_REST_Posts_Controller instance,
+		// and not just check that we have a valid controller as we use Posts Controller specific methods.
+		if ( ! $posts_controller instanceof WP_REST_Posts_Controller ) {
+			$posts_controller = new WP_REST_Posts_Controller( $post->post_type );
+		}
+
+		$post_type = get_post_type_object( $post->post_type );
 
 		$has_password_filter = false;
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1592,15 +1592,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * @return bool Whether post can be read.
 	 */
 	protected function check_read_post_permission( $post, $request ) {
-		$posts_controller = WP_REST_Posts_Controller::get_for_post_type( $post->post_type );
+		$post_type        = get_post_type_object( $post->post_type );
+		$posts_controller = $post_type->get_rest_controller();
 
 		// We need to specifically assert that the posts controller is a WP_REST_Posts_Controller instance,
 		// and not just check that we have a valid controller as we use Posts Controller specific methods.
 		if ( ! $posts_controller instanceof WP_REST_Posts_Controller ) {
 			$posts_controller = new WP_REST_Posts_Controller( $post->post_type );
 		}
-
-		$post_type = get_post_type_object( $post->post_type );
 
 		$has_password_filter = false;
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -57,47 +57,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Gets the REST API controller for a post type.
-	 *
-	 * @since 5.3.0
-	 *
-	 * @param string $post_type
-	 * @return WP_REST_Controller|null The controller instance, or null if the specified is invalid or the post type
-	 *                                 is set not to show in rest.
-	 */
-	public static function get_for_post_type( $post_type ) {
-		if ( array_key_exists( $post_type, self::$post_type_controllers ) ) {
-			return self::$post_type_controllers[ $post_type ];
-		}
-
-		$definition = get_post_type_object( $post_type );
-
-		if ( ! $definition || ! $definition->show_in_rest ) {
-			self::$post_type_controllers[ $post_type ] = null;
-
-			return self::$post_type_controllers[ $post_type ];
-		}
-
-		$class = $definition->rest_controller_class ? $definition->rest_controller_class : WP_REST_Posts_Controller::class;
-
-		if ( ! class_exists( $class ) ) {
-			self::$post_type_controllers[ $post_type ] = null;
-
-			return self::$post_type_controllers[ $post_type ];
-		}
-
-		if ( ! is_subclass_of( $class, WP_REST_Controller::class ) ) {
-			self::$post_type_controllers[ $post_type ] = null;
-
-			return self::$post_type_controllers[ $post_type ];
-		}
-
-		self::$post_type_controllers[ $post_type ] = new $class( $post_type );
-
-		return self::$post_type_controllers[ $post_type ];
-	}
-
-	/**
 	 * Registers the routes for the objects of the controller.
 	 *
 	 * @since 4.7.0

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -17,6 +17,14 @@
 class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 	/**
+	 * Instances of post type controllers keyed by post type.
+	 *
+	 * @since 5.3.0
+	 * @var WP_REST_Controller[]
+	 */
+	private static $post_type_controllers = array();
+
+	/**
 	 * Post type.
 	 *
 	 * @since 4.7.0
@@ -46,6 +54,47 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$this->rest_base = ! empty( $obj->rest_base ) ? $obj->rest_base : $obj->name;
 
 		$this->meta = new WP_REST_Post_Meta_Fields( $this->post_type );
+	}
+
+	/**
+	 * Gets the REST API controller for a post type.
+	 *
+	 * @since 5.3.0
+	 *
+	 * @param string $post_type
+	 * @return WP_REST_Controller|null The controller instance, or null if the specified is invalid or the post type
+	 *                                 is set not to show in rest.
+	 */
+	public static function get_for_post_type( $post_type ) {
+		if ( array_key_exists( $post_type, self::$post_type_controllers ) ) {
+			return self::$post_type_controllers[ $post_type ];
+		}
+
+		$definition = get_post_type_object( $post_type );
+
+		if ( ! $definition || ! $definition->show_in_rest ) {
+			self::$post_type_controllers[ $post_type ] = null;
+
+			return self::$post_type_controllers[ $post_type ];
+		}
+
+		$class = $definition->rest_controller_class ? $definition->rest_controller_class : WP_REST_Posts_Controller::class;
+
+		if ( ! class_exists( $class ) ) {
+			self::$post_type_controllers[ $post_type ] = null;
+
+			return self::$post_type_controllers[ $post_type ];
+		}
+
+		if ( ! is_subclass_of( $class, WP_REST_Controller::class ) ) {
+			self::$post_type_controllers[ $post_type ] = null;
+
+			return self::$post_type_controllers[ $post_type ];
+		}
+
+		self::$post_type_controllers[ $post_type ] = new $class( $post_type );
+
+		return self::$post_type_controllers[ $post_type ];
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -48,18 +48,16 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 * @param string $parent_post_type Post type of the parent.
 	 */
 	public function __construct( $parent_post_type ) {
-		$parent_controller = WP_REST_Posts_Controller::get_for_post_type( $parent_post_type );
-
-		if ( ! $parent_controller ) {
-			$parent_controller = new WP_REST_Posts_Controller( $parent_post_type );
-		}
-
 		$this->parent_post_type  = $parent_post_type;
-		$this->parent_controller = $parent_controller;
 		$this->namespace         = 'wp/v2';
 		$this->rest_base         = 'revisions';
 		$post_type_object        = get_post_type_object( $parent_post_type );
 		$this->parent_base       = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
+		$this->parent_controller = $post_type_object->get_rest_controller();
+
+		if ( ! $this->parent_controller ) {
+			$this->parent_controller = new WP_REST_Posts_Controller( $parent_post_type );
+		}
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -48,8 +48,14 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 * @param string $parent_post_type Post type of the parent.
 	 */
 	public function __construct( $parent_post_type ) {
+		$parent_controller = WP_REST_Posts_Controller::get_for_post_type( $parent_post_type );
+
+		if ( ! $parent_controller ) {
+			$parent_controller = new WP_REST_Posts_Controller( $parent_post_type );
+		}
+
 		$this->parent_post_type  = $parent_post_type;
-		$this->parent_controller = new WP_REST_Posts_Controller( $parent_post_type );
+		$this->parent_controller = $parent_controller;
 		$this->namespace         = 'wp/v2';
 		$this->rest_base         = 'revisions';
 		$post_type_object        = get_post_type_object( $parent_post_type );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -4526,6 +4526,94 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertNotEquals( '0000-00-00 00:00:00', get_post( $post->ID )->post_date_gmt );
 	}
 
+	/**
+	 * @ticket 45677
+	 */
+	public function test_get_for_post_type_reuses_same_instance() {
+		$this->assertSame(
+			WP_REST_Posts_Controller::get_for_post_type( 'post' ),
+			WP_REST_Posts_Controller::get_for_post_type( 'post' )
+		);
+	}
+
+	/**
+	 * @ticket 45677
+	 */
+	public function test_get_for_post_type_returns_null_for_non_existent_post_type() {
+		$this->assertNull( WP_REST_Posts_Controller::get_for_post_type( 'doesnotexist' ) );
+	}
+
+	/**
+	 * @ticket 45677
+	 */
+	public function test_get_for_post_type_returns_null_if_post_type_does_not_show_in_rest() {
+		register_post_type(
+			'not_in_rest',
+			array(
+				'show_in_rest' => false,
+			)
+		);
+
+		$this->assertNull( WP_REST_Posts_Controller::get_for_post_type( 'not_in_rest' ) );
+	}
+
+	/**
+	 * @ticket 45677
+	 */
+	public function test_get_for_post_type_returns_null_if_class_does_not_exist() {
+		register_post_type(
+			'class_not_found',
+			array(
+				'show_in_rest'          => true,
+				'rest_controller_class' => 'Class_That_Does_Not_Exist',
+			)
+		);
+
+		$this->assertNull( WP_REST_Posts_Controller::get_for_post_type( 'class_not_found' ) );
+	}
+
+	/**
+	 * @ticket 45677
+	 */
+	public function test_get_for_post_type_returns_null_if_class_does_not_subclass_rest_controller() {
+		register_post_type(
+			'invalid_class',
+			array(
+				'show_in_rest'          => true,
+				'rest_controller_class' => 'WP_Post',
+			),
+		);
+
+		$this->assertNull( WP_REST_Posts_Controller::get_for_post_type( 'invalid_class' ) );
+	}
+
+	/**
+	 * @ticket 45677
+	 */
+	public function test_get_for_post_type_returns_posts_controller_if_custom_class_not_specified() {
+		register_post_type(
+			'test',
+			array(
+				'show_in_rest' => true,
+			)
+		);
+
+		$this->assertInstanceOf(
+			WP_REST_Posts_Controller::class,
+			WP_REST_Posts_Controller::get_for_post_type( 'test' )
+		);
+	}
+
+	/**
+	 * @ticket 45677
+	 */
+	public function test_get_for_post_type_returns_provided_controller_class() {
+		$this->assertInstanceOf(
+			WP_REST_Blocks_Controller::class,
+			WP_REST_Posts_Controller::get_for_post_type( 'wp_block' )
+		);
+	}
+
 	public function tearDown() {
 		_unregister_post_type( 'private-post' );
 		_unregister_post_type( 'youseeme' );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -4531,16 +4531,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 */
 	public function test_get_for_post_type_reuses_same_instance() {
 		$this->assertSame(
-			WP_REST_Posts_Controller::get_for_post_type( 'post' ),
-			WP_REST_Posts_Controller::get_for_post_type( 'post' )
+			get_post_type_object( 'post' )->get_rest_controller(),
+			get_post_type_object( 'post' )->get_rest_controller()
 		);
-	}
-
-	/**
-	 * @ticket 45677
-	 */
-	public function test_get_for_post_type_returns_null_for_non_existent_post_type() {
-		$this->assertNull( WP_REST_Posts_Controller::get_for_post_type( 'doesnotexist' ) );
 	}
 
 	/**
@@ -4554,7 +4547,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			)
 		);
 
-		$this->assertNull( WP_REST_Posts_Controller::get_for_post_type( 'not_in_rest' ) );
+		$this->assertNull( get_post_type_object( 'not_in_rest' )->get_rest_controller() );
 	}
 
 	/**
@@ -4569,7 +4562,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			)
 		);
 
-		$this->assertNull( WP_REST_Posts_Controller::get_for_post_type( 'class_not_found' ) );
+		$this->assertNull( get_post_type_object( 'class_not_found' )->get_rest_controller() );
 	}
 
 	/**
@@ -4584,7 +4577,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			),
 		);
 
-		$this->assertNull( WP_REST_Posts_Controller::get_for_post_type( 'invalid_class' ) );
+		$this->assertNull( get_post_type_object( 'invalid_class' )->get_rest_controller() );
 	}
 
 	/**
@@ -4600,7 +4593,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		$this->assertInstanceOf(
 			WP_REST_Posts_Controller::class,
-			WP_REST_Posts_Controller::get_for_post_type( 'test' )
+			get_post_type_object( 'test' )->get_rest_controller()
 		);
 	}
 
@@ -4610,7 +4603,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_for_post_type_returns_provided_controller_class() {
 		$this->assertInstanceOf(
 			WP_REST_Blocks_Controller::class,
-			WP_REST_Posts_Controller::get_for_post_type( 'wp_block' )
+			get_post_type_object( 'wp_block' )->get_rest_controller()
 		);
 	}
 


### PR DESCRIPTION
REST API: Introduce WP_Post_Type::get_rest_controller() caching method to prevent unnecessary REST controller construction.

Cache REST controller references on their associated post type object to prevent unnecessary controller re-instantiation, which previously caused "rest_prepare_{$post_type}" and "rest_{$post_type}_query" to run twice per request.

Props TimothyBlynJacobs, patrelentlesstechnologycom.
Fixes #45677.