### PR TITLE
#39953: Set "pending" status to date_floating.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -360,6 +360,7 @@ function create_initial_post_types() {
 				'Pending <span class="count">(%s)</span>',
 				'Pending <span class="count">(%s)</span>'
 			),
+			'date_floating' => true,
 		)
 	);
 


### PR DESCRIPTION
REST API: Mark "pending" status as date_floating.

See: https://github.com/WordPress/gutenberg/issues/13176

Props TimothyBlynJacobs.
Fixes #39953.