### PR TITLE
#48113: Dynamically build list of date-floating stati.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3727,7 +3727,7 @@ function wp_insert_post( $postarr, $wp_error = false ) {
 	}
 
 	if ( empty( $postarr['post_date_gmt'] ) || '0000-00-00 00:00:00' == $postarr['post_date_gmt'] ) {
-		if ( ! in_array( $post_status, array( 'draft', 'pending', 'auto-draft' ) ) ) {
+		if ( ! in_array( $post_status, get_post_stati( array( 'date_floating' => true ) ), true ) ) {
 			$post_date_gmt = get_gmt_from_date( $post_date );
 		} else {
 			$post_date_gmt = '0000-00-00 00:00:00';

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -1394,4 +1394,40 @@ class Tests_Post extends WP_UnitTestCase {
 	function filter_pre_wp_unique_post_slug( $default, $slug, $post_ID, $post_status, $post_type, $post_parent ) {
 		return 'override-slug-' . $post_type;
 	}
+
+	/**
+	 * @ticket 48113
+	 */
+	public function test_insert_post_should_respect_date_floating_post_status_arg() {
+		register_post_status( 'floating', array( 'date_floating' => true ) );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'floating',
+				'post_date'     => null,
+				'post_date_gmt' => null,
+			)
+		);
+
+		$post = get_post( $post_id );
+		self::assertEquals( '0000-00-00 00:00:00', $post->post_date_gmt );
+	}
+
+	/**
+	 * @ticket 48113
+	 */
+	public function test_insert_post_should_respect_date_floating_post_status_arg_not_set() {
+		register_post_status( 'not-floating', array( 'date_floating' => false ) );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'floating',
+				'post_date'     => null,
+				'post_date_gmt' => null,
+			)
+		);
+
+		$post = get_post( $post_id );
+		self::assertEquals( gmdate( 'Y-m-d H:i:s' ), $post->post_date_gmt );
+	}
 }


### PR DESCRIPTION
Posts, Post Types: Build list of "date floating" post stati dynamically when inserting post.

Completes work begun in #39953 to expose "date floating" status information to frontend clients via the REST API.

Props TimothyBlynJacobs.
Fixes #48113.