### PR TITLE
#48266: support sibling fields in _fields

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -743,7 +743,7 @@ function rest_filter_response_fields( $response, $server, $request ) {
 		$parts = explode( '.', $field );
 		$ref   = &$fields_as_keyed;
 		while ( count( $parts ) > 1 ) {
-			$next         = array_shift( $parts );
+			$next = array_shift( $parts );
 			if ( isset( $ref[ $next ] ) && true === $ref[ $next ] ) {
 				// Skip any sub-properties if their parent prop is already marked for inclusion.
 				break 2;

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -744,11 +744,11 @@ function rest_filter_response_fields( $response, $server, $request ) {
 		$ref   = &$fields_as_keyed;
 		while ( count( $parts ) > 1 ) {
 			$next         = array_shift( $parts );
-			$ref[ $next ] = array();
+			$ref[ $next ] = isset( $ref[ $next ] ) ? $ref[ $next ] : array();
 			$ref          = &$ref[ $next ];
 		}
 		$last         = array_shift( $parts );
-		$ref[ $last ] = true;
+		$ref[ $last ] = array();
 	}
 
 	if ( wp_is_numeric_array( $data ) ) {

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -744,11 +744,15 @@ function rest_filter_response_fields( $response, $server, $request ) {
 		$ref   = &$fields_as_keyed;
 		while ( count( $parts ) > 1 ) {
 			$next         = array_shift( $parts );
+			if ( isset( $ref[ $next ] ) && true === $ref[ $next ] ) {
+				// Skip any sub-properties if their parent prop is already marked for inclusion.
+				break 2;
+			}
 			$ref[ $next ] = isset( $ref[ $next ] ) ? $ref[ $next ] : array();
 			$ref          = &$ref[ $next ];
 		}
 		$last         = array_shift( $parts );
-		$ref[ $last ] = array();
+		$ref[ $last ] = true;
 	}
 
 	if ( wp_is_numeric_array( $data ) ) {

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -593,7 +593,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure that specifying a single top-level key in _fields includes that field and all children.
+	 * Ensure that a top-level key in _fields supersedes any specified children of that field.
 	 *
 	 * @ticket 48266
 	 */

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -561,9 +561,73 @@ class Tests_REST_API extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure that specifying a single top-level key in _fields includes that field and all children.
+	 *
+	 * @ticket 48266
+	 */
+	public function test_rest_filter_response_fields_top_level_key() {
+		$response = new WP_REST_Response();
+
+		$response->set_data(
+			array(
+				'meta' => array(
+					'key1' => 1,
+					'key2' => 2,
+				),
+			)
+		);
+		$request = array(
+			'_fields' => 'meta',
+		);
+
+		$response = rest_filter_response_fields( $response, null, $request );
+		$this->assertEquals(
+			array(
+				'meta' => array(
+					'key1' => 1,
+					'key2' => 2,
+				),
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Ensure that specifying a single top-level key in _fields includes that field and all children.
+	 *
+	 * @ticket 48266
+	 */
+	public function test_rest_filter_response_fields_child_after_parent() {
+		$response = new WP_REST_Response();
+
+		$response->set_data(
+			array(
+				'meta' => array(
+					'key1' => 1,
+					'key2' => 2,
+				),
+			)
+		);
+		$request = array(
+			'_fields' => 'meta,meta.key1',
+		);
+
+		$response = rest_filter_response_fields( $response, null, $request );
+		$this->assertEquals(
+			array(
+				'meta' => array(
+					'key1' => 1,
+					'key2' => 2,
+				),
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
 	 * Ensure that specifying two sibling properties in _fields causes both to be included.
 	 *
-	 * @ticket 42094
+	 * @ticket 48266
 	 */
 	public function test_rest_filter_response_fields_include_all_specified_siblings() {
 		$response = new WP_REST_Response();

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -570,37 +570,22 @@ class Tests_REST_API extends WP_UnitTestCase {
 
 		$response->set_data(
 			array(
-				'a' => 0,
-				'b' => array(
-					'1' => 1,
-					'2' => array (
-						'aa' => 1,
-						'bb' => 2,
-					),
-				),
-				'c' => 3,
-				'd' => array(
-					'4' => 4,
-					'5' => 5,
+				'meta' => array(
+					'key1' => 1,
+					'key2' => 2,
 				),
 			)
 		);
 		$request = array(
-			'_fields' => 'b.2.bb,b.2.aa,d.4,d.5',
+			'_fields' => 'meta.key1,meta.key2',
 		);
 
 		$response = rest_filter_response_fields( $response, null, $request );
 		$this->assertEquals(
 			array(
-				'b' => array(
-					'2' => array (
-						'aa' => 1,
-						'bb' => 2,
-					),
-				),
-				'd' => array(
-					'4' => 4,
-					'5' => 5,
+				'meta' => array(
+					'key1' => 1,
+					'key2' => 2,
 				),
 			),
 			$response->get_data()

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -561,6 +561,53 @@ class Tests_REST_API extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure that specifying two sibling properties in _fields causes both to be included.
+	 *
+	 * @ticket 42094
+	 */
+	public function test_rest_filter_response_fields_include_all_specified_siblings() {
+		$response = new WP_REST_Response();
+
+		$response->set_data(
+			array(
+				'a' => 0,
+				'b' => array(
+					'1' => 1,
+					'2' => array (
+						'aa' => 1,
+						'bb' => 2,
+					),
+				),
+				'c' => 3,
+				'd' => array(
+					'4' => 4,
+					'5' => 5,
+				),
+			)
+		);
+		$request = array(
+			'_fields' => 'b.2.bb,b.2.aa,d.4,d.5',
+		);
+
+		$response = rest_filter_response_fields( $response, null, $request );
+		$this->assertEquals(
+			array(
+				'b' => array(
+					'2' => array (
+						'aa' => 1,
+						'bb' => 2,
+					),
+				),
+				'd' => array(
+					'4' => 4,
+					'5' => 5,
+				),
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
 	 * @ticket 42094
 	 */
 	public function test_rest_is_field_included() {


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/48266

REST API: Fix error in _fields filtering logic where only one of several requested sibling properties would be included.

Props kadamwhite, TimothyBlynJacobs.
Fixes #48266.