### PR TITLE
#48401: Issue doing_it_wrong if taxonomy rest base is already in use

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -2246,7 +2246,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 			if ( array_key_exists( $base, $schema['properties'] ) ) {
 				$taxonomy_field_name_with_conflict = ! empty( $taxonomy->rest_base ) ? 'rest_base' : 'name';
-				_doing_it_wrong( 'register_taxonomy', sprintf( __( 'The "%1$s" taxonomy %2$s conflicts with an existing property on the REST API Posts Controller. Specify a custom "rest_base" when registering the taxonomy to avoid this error.' ), $base, $taxonomy_field_name_with_conflict ), '5.4.0' );
+				_doing_it_wrong(
+					'register_taxonomy',
+					sprintf(
+						/* translators: 1. The taxonomy name, 2. The property name, either rest_base or name. */
+						__( 'The "%1$s" taxonomy "%2$s" conflicts with an existing property on the REST API Posts Controller. Specify a custom "rest_base" when registering the taxonomy to avoid this error.' ),
+						$base,
+						$taxonomy_field_name_with_conflict
+					),
+					'5.4.0'
+				);
 			}
 
 			$schema['properties'][ $base ] = array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -2242,7 +2242,13 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
 		foreach ( $taxonomies as $taxonomy ) {
-			$base                          = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
+			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
+
+			if ( array_key_exists( $base, $schema['properties'] ) ) {
+				$taxonomy_field_name_with_conflict = ! empty( $taxonomy->rest_base ) ? 'rest_base' : 'name';
+				_doing_it_wrong( 'register_taxonomy', sprintf( __( 'The "%1$s" taxonomy %2$s conflicts with an existing property on the REST API Posts Controller. Specify a custom "rest_base" when registering the taxonomy to avoid this error.' ), $base, $taxonomy_field_name_with_conflict ), '5.4.0' );
+			}
+
 			$schema['properties'][ $base ] = array(
 				/* translators: %s: Taxonomy name. */
 				'description' => sprintf( __( 'The terms assigned to the object in the %s taxonomy.' ), $taxonomy->name ),

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -3919,6 +3919,20 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	/**
+	 * @ticket 48401
+	 */
+	public function test_get_item_schema_issues_doing_it_wrong_when_taxonomy_name_is_already_set_in_properties() {
+		$this->setExpectedIncorrectUsage( 'register_taxonomy' );
+
+		// Register a taxonomy with 'status' as name.
+		register_taxonomy( 'status', 'post', array( 'show_in_rest' => true ) );
+
+		// Re-initialize the controller
+		$controller = new WP_REST_Posts_Controller( 'post' );
+		$controller->register_routes();
+	}
+
+	/**
 	 * @ticket 39805
 	 */
 	public function test_get_post_view_context_properties() {


### PR DESCRIPTION
REST API: Issue doing_it_wrong if a taxonomy's specified rest_base is already in use by a different resource.

Props fgiannar, TimothyBlynJacobs, kingkool68, SergeyBiryukov.
Fixes #48401.