### PR TITLE
#48838: Consider "caching" embedded REST API requests

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -742,22 +742,22 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$response = new WP_REST_Response(
 			array(
 				array(
-					'id' => 1,
+					'id'     => 1,
 					'_links' => array(
 						'author' => array(
 							array(
-								'href' => rest_url( 'wp/v2/users/1' ),
+								'href'       => rest_url( 'wp/v2/users/1' ),
 								'embeddable' => true,
 							),
 						),
 					),
 				),
 				array(
-					'id' => 2,
+					'id'     => 2,
 					'_links' => array(
 						'author' => array(
 							array(
-								'href' => rest_url( 'wp/v2/users/1' ),
+								'href'       => rest_url( 'wp/v2/users/1' ),
 								'embeddable' => true,
 							),
 						),

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -690,15 +690,93 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertArrayHasKey( 'post', $data['_embedded'] );
 		$this->assertCount( 1, $data['_embedded']['post'] );
 
-		wp_update_post( array(
-			'ID'         => $post_id,
-			'post_title' => 'My Awesome Title',
-		) );
+		wp_update_post(
+			array(
+				'ID'         => $post_id,
+				'post_title' => 'My Awesome Title',
+			)
+		);
 
 		$data = rest_get_server()->response_to_data( $response, true );
 		$this->assertArrayHasKey( 'post', $data['_embedded'] );
 		$this->assertCount( 1, $data['_embedded']['post'] );
 		$this->assertEquals( 'My Awesome Title', $data['_embedded']['post'][0]['title']['rendered'] );
+	}
+
+	/**
+	 * @ticket 48838
+	 */
+	public function test_link_embedding_cache() {
+		$response = new WP_REST_Response(
+			array(
+				'id' => 1,
+			)
+		);
+		$response->add_link(
+			'author',
+			rest_url( 'wp/v2/users/1' ),
+			array( 'embeddable' => true )
+		);
+		$response->add_link(
+			'author',
+			rest_url( 'wp/v2/users/1' ),
+			array( 'embeddable' => true )
+		);
+
+		$mock = new MockAction();
+		add_filter( 'rest_post_dispatch', array( $mock, 'filter' ) );
+
+		$data = rest_get_server()->response_to_data( $response, true );
+
+		$this->assertArrayHasKey( '_embedded', $data );
+		$this->assertArrayHasKey( 'author', $data['_embedded'] );
+		$this->assertCount( 2, $data['_embedded']['author'] );
+
+		$this->assertCount( 1, $mock->get_events() );
+	}
+
+	/**
+	 * @ticket 48838
+	 */
+	public function test_link_embedding_cache_collection() {
+		$response = new WP_REST_Response(
+			array(
+				array(
+					'id' => 1,
+					'_links' => array(
+						'author' => array(
+							array(
+								'href' => rest_url( 'wp/v2/users/1' ),
+								'embeddable' => true,
+							),
+						),
+					),
+				),
+				array(
+					'id' => 2,
+					'_links' => array(
+						'author' => array(
+							array(
+								'href' => rest_url( 'wp/v2/users/1' ),
+								'embeddable' => true,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$mock = new MockAction();
+		add_filter( 'rest_post_dispatch', array( $mock, 'filter' ) );
+
+		$data = rest_get_server()->response_to_data( $response, true );
+
+		$embeds = wp_list_pluck( $data, '_embedded' );
+		$this->assertCount( 2, $embeds );
+		$this->assertArrayHasKey( 'author', $embeds[0] );
+		$this->assertArrayHasKey( 'author', $embeds[1] );
+
+		$this->assertCount( 1, $mock->get_events() );
 	}
 
 	/**


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/48838#comment:2

REST API: Reuse previously-generated embedded objects when building collection response.

Store each generated embedded object in a temporary cache when querying for linked resources so that repeated links to the same resource do not trigger repeated queries or processing.

Props TimothyBlynJacobs.
Fixes #48838.