### PR TITLE
Trac 49037/theme supports

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -110,20 +110,44 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$fields = $this->get_fields_for_response( $request );
 
 		if ( in_array( 'theme_supports', $fields, true ) ) {
-			$formats                           = get_theme_support( 'post-formats' );
-			$formats                           = is_array( $formats ) ? array_values( $formats[0] ) : array();
-			$formats                           = array_merge( array( 'standard' ), $formats );
-			$data['theme_supports']['formats'] = $formats;
+			$item_schemas   = $this->get_item_schema();
+			$theme_supports = $item_schemas['properties']['theme_supports']['properties'];
+			foreach ( $theme_supports as $name => $schema ) {
+				if ( 'formats' === $name ) {
+					continue;
+				}
 
-			$data['theme_supports']['post-thumbnails']   = false;
-			$data['theme_supports']['responsive-embeds'] = (bool) get_theme_support( 'responsive-embeds' );
-			$post_thumbnails                             = get_theme_support( 'post-thumbnails' );
+				if ( ! current_theme_supports( $name ) ) {
+					$data['theme_supports'][ $name ] = false;
+					continue;
+				}
 
-			if ( $post_thumbnails ) {
-				// $post_thumbnails can contain a nested array of post types.
-				// e.g. array( array( 'post', 'page' ) ).
-				$data['theme_supports']['post-thumbnails'] = is_array( $post_thumbnails ) ? $post_thumbnails[0] : true;
+				if ( 'boolean' === $schema['type'] ) {
+					$data['theme_supports'][ $name ] = true;
+					continue;
+				}
+
+				$support = get_theme_support( $name );
+
+				if ( is_array( $support ) ) {
+					// None of the Core theme supports have variadic args.
+					$support = $support[0];
+
+					if ( is_array( $schema['type'] ) && in_array( 'boolean', $schema['type'], true ) ) {
+						// The schema sanitizer cannot handle a value that won't pass validation when using multiple types.
+						// This happens when a theme support has properties that are not not defined in the schema.
+						$schema['type'] = $schema['type'][1];
+					}
+				}
+
+				$data['theme_supports'][ $name ] = rest_sanitize_value_from_schema( $support, $schema );
 			}
+
+			$formats = get_theme_support( 'post-formats' );
+			$formats = is_array( $formats ) ? array_values( $formats[0] ) : array();
+			$formats = array_merge( array( 'standard' ), $formats );
+
+			$data['theme_supports']['formats'] = $formats;
 		}
 
 		$data = $this->add_additional_fields_to_object( $data, $request );
@@ -162,23 +186,267 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'properties' => array(
 				'theme_supports' => array(
 					'description' => __( 'Features supported by this theme.' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'readonly'    => true,
 					'properties'  => array(
-						'formats'           => array(
+						'align-wide'                => array(
+							'description' => __( 'Whether theme opts in to wide alignment CSS class.' ),
+							'type'        => 'boolean',
+						),
+						'automatic-feed-links'      => array(
+							'description' => __( 'Whether posts and comments RSS feed links are added to head.' ),
+							'type'        => 'boolean',
+						),
+						'custom-header'             => array(
+							'description'          => __( 'Custom header if defined by the theme.' ),
+							'type'                 => array( 'boolean', 'object' ),
+							'properties'           => array(
+								'default-image'      => array(
+									'type'   => 'string',
+									'format' => 'uri',
+								),
+								'random-default'     => array(
+									'type' => 'boolean',
+								),
+								'width'              => array(
+									'type' => 'integer',
+								),
+								'height'             => array(
+									'type' => 'integer',
+								),
+								'flex-height'        => array(
+									'type' => 'boolean',
+								),
+								'flex-width'         => array(
+									'type' => 'boolean',
+								),
+								'default-text-color' => array(
+									'type' => 'string',
+								),
+								'header-text'        => array(
+									'type' => 'boolean',
+								),
+								'uploads'            => array(
+									'type' => 'boolean',
+								),
+								'video'              => array(
+									'type' => 'boolean',
+								),
+							),
+							'additionalProperties' => false,
+						),
+						'custom-background'         => array(
+							'description'          => __( 'Custom background if defined by the theme.' ),
+							'type'                 => array( 'boolean', 'object' ),
+							'properties'           => array(
+								'default-image'      => array(
+									'type'   => 'string',
+									'format' => 'uri',
+								),
+								'default-preset'     => array(
+									'type' => 'string',
+									'enum' => array(
+										'default',
+										'fill',
+										'fit',
+										'repeat',
+										'custom',
+									),
+								),
+								'default-position-x' => array(
+									'type' => 'string',
+									'enum' => array(
+										'left',
+										'center',
+										'right',
+									),
+								),
+								'default-position-y' => array(
+									'type' => 'string',
+									'enum' => array(
+										'left',
+										'center',
+										'right',
+									),
+								),
+								'default-size'       => array(
+									'type' => 'string',
+									'enum' => array(
+										'auto',
+										'contain',
+										'cover',
+									),
+								),
+								'default-repeat'     => array(
+									'type' => 'string',
+									'enum' => array(
+										'repeat-x',
+										'repeat-y',
+										'repeat',
+										'no-repeat',
+									),
+								),
+								'default-attachment' => array(
+									'type' => 'string',
+									'enum' => array(
+										'scroll',
+										'fixed',
+									),
+								),
+								'default-color'      => array(
+									'type' => 'string',
+								),
+							),
+							'additionalProperties' => false,
+						),
+						'custom-logo'               => array(
+							'description'          => __( 'Custom logo if defined by the theme.' ),
+							'type'                 => array( 'boolean', 'object' ),
+							'properties'           => array(
+								'width'       => array(
+									'type' => 'integer',
+								),
+								'height'      => array(
+									'type' => 'integer',
+								),
+								'flex-width'  => array(
+									'type' => 'boolean',
+								),
+								'flex-height' => array(
+									'type' => 'boolean',
+								),
+								'header-text' => array(
+									'type'  => 'array',
+									'items' => array(
+										'type' => 'string',
+									),
+								),
+							),
+							'additionalProperties' => false,
+						),
+						'customize-selective-refresh-widgets' => array(
+							'description' => __( 'Whether the theme enables Selective Refresh for Widgets being managed with the Customizer.' ),
+							'type'        => 'boolean',
+						),
+						'dark-editor-style'         => array(
+							'description' => __( 'Whether theme opts in to the dark editor style UI.' ),
+							'type'        => 'boolean',
+						),
+						'disable-custom-colors'     => array(
+							'description' => __( 'Whether the theme disables custom colors.' ),
+							'type'        => 'boolean',
+						),
+						'disable-custom-font-sizes' => array(
+							'description' => __( 'Whether the theme disables custom font sizes.' ),
+							'type'        => 'boolean',
+						),
+						'disable-custom-gradients'  => array(
+							'description' => __( 'Whether the theme disables custom graidients.' ),
+							'type'        => 'boolean',
+						),
+						'editor-color-palette'      => array(
+							'description' => __( 'Custom color palette if defined by the theme.' ),
+							'type'        => array( 'boolean', 'array' ),
+							'items'       => array(
+								'type'                 => 'object',
+								'properties'           => array(
+									'name'  => array(
+										'type' => 'string',
+									),
+									'slug'  => array(
+										'type' => 'string',
+									),
+									'color' => array(
+										'type' => 'string',
+									),
+								),
+								'additionalProperties' => false,
+							),
+						),
+						'editor-font-sizes'         => array(
+							'description' => __( 'Custom font sizes if defined by the theme.' ),
+							'type'        => array( 'boolean', 'array' ),
+							'items'       => array(
+								'type'                 => 'object',
+								'properties'           => array(
+									'name' => array(
+										'type' => 'string',
+									),
+									'size' => array(
+										'type' => 'number',
+									),
+									'slug' => array(
+										'type' => 'string',
+									),
+								),
+								'additionalProperties' => false,
+							),
+						),
+						'editor-gradient-presets'   => array(
+							'description' => __( 'Custom gradient presets if defined by the theme.' ),
+							'type'        => array( 'boolean', 'array' ),
+							'items'       => array(
+								'type'                 => 'object',
+								'properties'           => array(
+									'name'     => array(
+										'type' => 'string',
+									),
+									'gradient' => array(
+										'type' => 'string',
+									),
+									'slug'     => array(
+										'type' => 'string',
+									),
+								),
+								'additionalProperties' => false,
+							),
+						),
+						'editor-styles'             => array(
+							'description' => __( 'Whether theme opts in to the editor styles CSS wrapper.' ),
+							'type'        => 'boolean',
+						),
+						'formats'                   => array(
 							'description' => __( 'Post formats supported.' ),
 							'type'        => 'array',
-							'readonly'    => true,
+							'items'       => array(
+								'type' => 'string',
+								'enum' => get_post_format_slugs(),
+							),
 						),
-						'post-thumbnails'   => array(
+						'html5'                     => array(
+							'description' => __( 'Allows use of html5 markup for search forms, comment forms, comment lists, gallery, and caption.' ),
+							'type'        => array( 'boolean', 'array' ),
+							'items'       => array(
+								'type' => 'string',
+								'enum' => array(
+									'search-form',
+									'comment-form',
+									'comment-list',
+									'gallery',
+									'caption',
+									'script',
+									'style',
+								),
+							),
+						),
+						'post-thumbnails'           => array(
 							'description' => __( 'Whether the theme supports post thumbnails.' ),
-							'type'        => array( 'array', 'bool' ),
-							'readonly'    => true,
+							'type'        => array( 'boolean', 'array' ),
+							'items'       => array(
+								'type' => 'string',
+							),
 						),
-						'responsive-embeds' => array(
+						'responsive-embeds'         => array(
 							'description' => __( 'Whether the theme supports responsive embedded content.' ),
-							'type'        => 'bool',
-							'readonly'    => true,
+							'type'        => 'boolean',
+						),
+						'title-tag'                 => array(
+							'description' => __( 'Whether the theme can manage the document title tag.' ),
+							'type'        => 'boolean',
+						),
+						'wp-block-styles'           => array(
+							'description' => __( 'Whether theme opts in to default WordPress block styles for viewing.' ),
+							'type'        => 'boolean',
 						),
 					),
 				),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -133,9 +133,11 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					// None of the Core theme supports have variadic args.
 					$support = $support[0];
 
-					if ( is_array( $schema['type'] ) && in_array( 'boolean', $schema['type'], true ) ) {
-						// The schema sanitizer cannot handle a value that won't pass validation when using multiple types.
-						// This happens when a theme support has properties that are not not defined in the schema.
+					// Core multi-type theme-support schema definitions always list boolean first.
+					if ( is_array( $schema['type'] ) && 'boolean' === $schema['type'][0] ) {
+						// Pass the non-boolean type through to the sanitizer, which cannot itself
+						// determine the intended type if the value is invalid (for example if an
+						// object includes non-safelisted properties).
 						$schema['type'] = $schema['type'][1];
 					}
 				}

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -188,11 +188,499 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 1, count( $properties ) );
 		$this->assertArrayHasKey( 'theme_supports', $properties );
-
-		$this->assertEquals( 3, count( $properties['theme_supports']['properties'] ) );
+		$this->assertEquals( 20, count( $properties['theme_supports']['properties'] ) );
+		$this->assertArrayHasKey( 'align-wide', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'automatic-feed-links', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'custom-header', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'custom-background', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'custom-logo', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'customize-selective-refresh-widgets', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'title-tag', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'dark-editor-style', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'disable-custom-font-sizes', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'disable-custom-gradients', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'editor-color-palette', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'editor-font-sizes', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'editor-gradient-presets', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'editor-styles', $properties['theme_supports']['properties'] );
 		$this->assertArrayHasKey( 'formats', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'html5', $properties['theme_supports']['properties'] );
 		$this->assertArrayHasKey( 'post-thumbnails', $properties['theme_supports']['properties'] );
 		$this->assertArrayHasKey( 'responsive-embeds', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'title-tag', $properties['theme_supports']['properties'] );
+		$this->assertArrayHasKey( 'wp-block-styles', $properties['theme_supports']['properties'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_disable_custom_colors_false() {
+		remove_theme_support( 'disable-custom-colors' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['disable-custom-colors'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['disable-custom-colors'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_disable_custom_colors_true() {
+		remove_theme_support( 'disable-custom-colors' );
+		add_theme_support( 'disable-custom-colors' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( $result[0]['theme_supports']['disable-custom-colors'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_disable_custom_font_sizes_false() {
+		remove_theme_support( 'disable-custom-font-sizes' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['disable-custom-font-sizes'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['disable-custom-font-sizes'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_disable_custom_font_sizes_true() {
+		remove_theme_support( 'disable-custom-font-sizes' );
+		add_theme_support( 'disable-custom-font-sizes' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( $result[0]['theme_supports']['disable-custom-font-sizes'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_editor_font_sizes_false() {
+		remove_theme_support( 'editor-font-sizes' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['editor-font-sizes'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['editor-font-sizes'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_editor_font_sizes_array() {
+		remove_theme_support( 'editor-font-sizes' );
+		$tiny = array(
+			'name' => 'Tiny',
+			'size' => 8,
+			'slug' => 'tiny',
+		);
+		add_theme_support( 'editor-font-sizes', array( $tiny ) );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['editor-font-sizes'] ) );
+		$this->assertEquals( array( $tiny ), $result[0]['theme_supports']['editor-font-sizes'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_editor_color_palette_false() {
+		remove_theme_support( 'editor-color-palette' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['editor-color-palette'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['editor-color-palette'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_editor_color_palette_array() {
+		remove_theme_support( 'editor-color-palette' );
+		$wordpress_blue = array(
+			'name'  => 'WordPress Blue',
+			'slug'  => 'wordpress-blue',
+			'color' => '#0073AA',
+		);
+		add_theme_support( 'editor-color-palette', array( $wordpress_blue ) );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertEquals( array( $wordpress_blue ), $result[0]['theme_supports']['editor-color-palette'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_enable_automatic_feed_links() {
+		remove_theme_support( 'automatic-feed-links' );
+		add_theme_support( 'automatic-feed-links' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( $result[0]['theme_supports']['automatic-feed-links'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_does_not_enable_automatic_feed_links() {
+		remove_theme_support( 'automatic-feed-links' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['automatic-feed-links'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['automatic-feed-links'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_does_not_support_custom_logo() {
+		remove_theme_support( 'custom-logo' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['custom-logo'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['custom-logo'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_custom_logo() {
+		remove_theme_support( 'custom-logo' );
+		$wordpress_logo = array(
+			'height'      => 100,
+			'width'       => 400,
+			'flex-height' => true,
+			'flex-width'  => true,
+			'header-text' => array( 'site-title', 'site-description' ),
+		);
+		add_theme_support( 'custom-logo', $wordpress_logo );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertEquals( $wordpress_logo, $result[0]['theme_supports']['custom-logo'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_does_not_support_custom_header() {
+		remove_theme_support( 'custom-header' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['custom-header'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['custom-header'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_custom_header() {
+		remove_theme_support( 'custom-header' );
+		$wordpress_header = array(
+			'default-image'          => 'https://s.w.org/style/images/wporg-logo.svg',
+			'random-default'         => false,
+			'width'                  => 0,
+			'height'                 => 0,
+			'flex-height'            => false,
+			'flex-width'             => false,
+			'default-text-color'     => '',
+			'header-text'            => true,
+			'uploads'                => true,
+			'wp-head-callback'       => '',
+			'admin-head-callback'    => '',
+			'admin-preview-callback' => '',
+			'video'                  => false,
+			'video-active-callback'  => 'is_front_page',
+		);
+		$excluded         = array(
+			'wp-head-callback',
+			'admin-head-callback',
+			'admin-preview-callback',
+			'video-active-callback',
+		);
+		add_theme_support( 'custom-header', $wordpress_header );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+
+		$expected = array_diff_key( $wordpress_header, array_flip( $excluded ) );
+		$this->assertEquals( $expected, $result[0]['theme_supports']['custom-header'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_does_not_support_custom_background() {
+		remove_theme_support( 'custom-background' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['custom-background'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['custom-background'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_custom_background() {
+		remove_theme_support( 'custom-background' );
+		$background = array(
+			'default-image'          => '',
+			'default-preset'         => 'default',
+			'default-position-x'     => 'left',
+			'default-position-y'     => 'top',
+			'default-size'           => 'auto',
+			'default-repeat'         => 'repeat',
+			'default-attachment'     => 'scroll',
+			'default-color'          => '',
+			'wp-head-callback'       => '_custom_background_cb',
+			'admin-head-callback'    => '',
+			'admin-preview-callback' => '',
+		);
+		$excluded   = array(
+			'wp-head-callback',
+			'admin-head-callback',
+			'admin-preview-callback',
+		);
+		add_theme_support( 'custom-background', $background );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+
+		$expected = array_diff_key( $background, array_flip( $excluded ) );
+		$this->assertEquals( $expected, $result[0]['theme_supports']['custom-background'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_does_not_support_html5() {
+		remove_theme_support( 'html5' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['html5'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['html5'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_html5() {
+		remove_theme_support( 'html5' );
+		$html5 = array(
+			'search-form',
+			'comment-form',
+			'comment-list',
+			'gallery',
+			'caption',
+			'script',
+			'style',
+		);
+		add_theme_support( 'html5', $html5 );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertEquals( $html5, $result[0]['theme_supports']['html5'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_cannot_manage_title_tag() {
+		remove_theme_support( 'title-tag' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['title-tag'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['title-tag'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_can_manage_title_tag() {
+		global $_wp_theme_features;
+		$_wp_theme_features['title-tag'] = true;
+		$response                        = self::perform_active_theme_request();
+		$result                          = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( $result[0]['theme_supports']['title-tag'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_cannot_manage_selective_refresh_for_widgets() {
+		remove_theme_support( 'customize-selective-refresh-widgets' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['customize-selective-refresh-widgets'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['customize-selective-refresh-widgets'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_can_manage_selective_refresh_for_widgets() {
+		remove_theme_support( 'customize-selective-refresh-widgets' );
+		add_theme_support( 'customize-selective-refresh-widgets' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( $result[0]['theme_supports']['customize-selective-refresh-widgets'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_no_wp_block_styles() {
+		remove_theme_support( 'wp-block-styles' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['wp-block-styles'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['wp-block-styles'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_wp_block_styles_optin() {
+		remove_theme_support( 'wp-block-styles' );
+		add_theme_support( 'wp-block-styles' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( $result[0]['theme_supports']['wp-block-styles'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_no_align_wide() {
+		remove_theme_support( 'align-wide' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['align-wide'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['align-wide'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_align_wide_optin() {
+		remove_theme_support( 'align-wide' );
+		add_theme_support( 'align-wide' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( $result[0]['theme_supports']['align-wide'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_no_editor_styles() {
+		remove_theme_support( 'editor-styles' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['editor-styles'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['editor-styles'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_editor_styles_optin() {
+		remove_theme_support( 'editor-styles' );
+		add_theme_support( 'editor-styles' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( $result[0]['theme_supports']['editor-styles'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_no_dark_editor_style() {
+		remove_theme_support( 'dark-editor-style' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['dark-editor-style'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['dark-editor-style'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_dark_editor_style_optin() {
+		remove_theme_support( 'dark-editor-style' );
+		add_theme_support( 'dark-editor-style' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( $result[0]['theme_supports']['dark-editor-style'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_no_disable_custom_gradients() {
+		remove_theme_support( 'disable-custom-gradients' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( isset( $result[0]['theme_supports']['disable-custom-gradients'] ) );
+		$this->assertFalse( $result[0]['theme_supports']['disable-custom-gradients'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_disable_custom_gradients() {
+		remove_theme_support( 'disable-custom-gradients' );
+		add_theme_support( 'disable-custom-gradients' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertTrue( $result[0]['theme_supports']['disable-custom-gradients'] );
+	}
+
+	/**
+	 * @ticket 49037
+	 */
+	public function test_theme_supports_editor_gradient_presets_array() {
+		remove_theme_support( 'editor-gradient-presets' );
+		$gradient = array(
+			'name'     => __( 'Vivid cyan blue to vivid purple', 'themeLangDomain' ),
+			'gradient' => 'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+			'slug'     => 'vivid-cyan-blue-to-vivid-purple',
+		);
+		add_theme_support( 'editor-gradient-presets', array( $gradient ) );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertEquals( array( $gradient ), $result[0]['theme_supports']['editor-gradient-presets'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -188,27 +188,28 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 1, count( $properties ) );
 		$this->assertArrayHasKey( 'theme_supports', $properties );
-		$this->assertEquals( 20, count( $properties['theme_supports']['properties'] ) );
-		$this->assertArrayHasKey( 'align-wide', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'automatic-feed-links', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'custom-header', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'custom-background', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'custom-logo', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'customize-selective-refresh-widgets', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'title-tag', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'dark-editor-style', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'disable-custom-font-sizes', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'disable-custom-gradients', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'editor-color-palette', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'editor-font-sizes', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'editor-gradient-presets', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'editor-styles', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'formats', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'html5', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'post-thumbnails', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'responsive-embeds', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'title-tag', $properties['theme_supports']['properties'] );
-		$this->assertArrayHasKey( 'wp-block-styles', $properties['theme_supports']['properties'] );
+		$theme_supports = $properties['theme_supports']['properties'];
+		$this->assertEquals( 20, count( $theme_supports ) );
+		$this->assertArrayHasKey( 'align-wide', $theme_supports );
+		$this->assertArrayHasKey( 'automatic-feed-links', $theme_supports );
+		$this->assertArrayHasKey( 'custom-header', $theme_supports );
+		$this->assertArrayHasKey( 'custom-background', $theme_supports );
+		$this->assertArrayHasKey( 'custom-logo', $theme_supports );
+		$this->assertArrayHasKey( 'customize-selective-refresh-widgets', $theme_supports );
+		$this->assertArrayHasKey( 'title-tag', $theme_supports );
+		$this->assertArrayHasKey( 'dark-editor-style', $theme_supports );
+		$this->assertArrayHasKey( 'disable-custom-font-sizes', $theme_supports );
+		$this->assertArrayHasKey( 'disable-custom-gradients', $theme_supports );
+		$this->assertArrayHasKey( 'editor-color-palette', $theme_supports );
+		$this->assertArrayHasKey( 'editor-font-sizes', $theme_supports );
+		$this->assertArrayHasKey( 'editor-gradient-presets', $theme_supports );
+		$this->assertArrayHasKey( 'editor-styles', $theme_supports );
+		$this->assertArrayHasKey( 'formats', $theme_supports );
+		$this->assertArrayHasKey( 'html5', $theme_supports );
+		$this->assertArrayHasKey( 'post-thumbnails', $theme_supports );
+		$this->assertArrayHasKey( 'responsive-embeds', $theme_supports );
+		$this->assertArrayHasKey( 'title-tag', $theme_supports );
+		$this->assertArrayHasKey( 'wp-block-styles', $theme_supports );
 	}
 
 	/**
@@ -218,8 +219,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'disable-custom-colors' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['disable-custom-colors'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'disable-custom-colors', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['disable-custom-colors'] );
 	}
 
@@ -231,7 +232,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'disable-custom-colors' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertTrue( $result[0]['theme_supports']['disable-custom-colors'] );
 	}
 
@@ -242,8 +243,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'disable-custom-font-sizes' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['disable-custom-font-sizes'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'disable-custom-font-sizes', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['disable-custom-font-sizes'] );
 	}
 
@@ -255,7 +256,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'disable-custom-font-sizes' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertTrue( $result[0]['theme_supports']['disable-custom-font-sizes'] );
 	}
 
@@ -266,8 +267,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'editor-font-sizes' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['editor-font-sizes'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'editor-font-sizes', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['editor-font-sizes'] );
 	}
 
@@ -284,8 +285,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'editor-font-sizes', array( $tiny ) );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['editor-font-sizes'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'editor-font-sizes', $result[0]['theme_supports'] );
 		$this->assertEquals( array( $tiny ), $result[0]['theme_supports']['editor-font-sizes'] );
 	}
 
@@ -296,8 +297,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'editor-color-palette' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['editor-color-palette'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'editor-color-palette', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['editor-color-palette'] );
 	}
 
@@ -314,7 +315,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'editor-color-palette', array( $wordpress_blue ) );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertEquals( array( $wordpress_blue ), $result[0]['theme_supports']['editor-color-palette'] );
 	}
 
@@ -326,7 +327,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'automatic-feed-links' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertTrue( $result[0]['theme_supports']['automatic-feed-links'] );
 	}
 
@@ -337,8 +338,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'automatic-feed-links' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['automatic-feed-links'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'automatic-feed-links', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['automatic-feed-links'] );
 	}
 
@@ -349,8 +350,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'custom-logo' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['custom-logo'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'custom-logo', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['custom-logo'] );
 	}
 
@@ -369,7 +370,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'custom-logo', $wordpress_logo );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertEquals( $wordpress_logo, $result[0]['theme_supports']['custom-logo'] );
 	}
 
@@ -380,8 +381,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'custom-header' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['custom-header'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'custom-header', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['custom-header'] );
 	}
 
@@ -415,7 +416,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'custom-header', $wordpress_header );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 
 		$expected = array_diff_key( $wordpress_header, array_flip( $excluded ) );
 		$this->assertEquals( $expected, $result[0]['theme_supports']['custom-header'] );
@@ -428,8 +429,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'custom-background' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['custom-background'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'custom-background', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['custom-background'] );
 	}
 
@@ -459,7 +460,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'custom-background', $background );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 
 		$expected = array_diff_key( $background, array_flip( $excluded ) );
 		$this->assertEquals( $expected, $result[0]['theme_supports']['custom-background'] );
@@ -472,8 +473,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'html5' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['html5'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'html5', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['html5'] );
 	}
 
@@ -494,7 +495,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'html5', $html5 );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertEquals( $html5, $result[0]['theme_supports']['html5'] );
 	}
 
@@ -505,8 +506,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'title-tag' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['title-tag'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'title-tag', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['title-tag'] );
 	}
 
@@ -518,7 +519,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$_wp_theme_features['title-tag'] = true;
 		$response                        = self::perform_active_theme_request();
 		$result                          = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertTrue( $result[0]['theme_supports']['title-tag'] );
 	}
 
@@ -529,8 +530,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'customize-selective-refresh-widgets' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['customize-selective-refresh-widgets'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'customize-selective-refresh-widgets', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['customize-selective-refresh-widgets'] );
 	}
 
@@ -542,7 +543,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'customize-selective-refresh-widgets' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertTrue( $result[0]['theme_supports']['customize-selective-refresh-widgets'] );
 	}
 
@@ -553,8 +554,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'wp-block-styles' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['wp-block-styles'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'wp-block-styles', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['wp-block-styles'] );
 	}
 
@@ -566,7 +567,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'wp-block-styles' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertTrue( $result[0]['theme_supports']['wp-block-styles'] );
 	}
 
@@ -577,8 +578,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'align-wide' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['align-wide'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'align-wide', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['align-wide'] );
 	}
 
@@ -590,7 +591,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'align-wide' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertTrue( $result[0]['theme_supports']['align-wide'] );
 	}
 
@@ -601,8 +602,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'editor-styles' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['editor-styles'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'editor-styles', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['editor-styles'] );
 	}
 
@@ -614,7 +615,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'editor-styles' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertTrue( $result[0]['theme_supports']['editor-styles'] );
 	}
 
@@ -625,8 +626,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'dark-editor-style' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['dark-editor-style'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'dark-editor-style', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['dark-editor-style'] );
 	}
 
@@ -638,7 +639,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'dark-editor-style' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertTrue( $result[0]['theme_supports']['dark-editor-style'] );
 	}
 
@@ -649,8 +650,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_theme_support( 'disable-custom-gradients' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
-		$this->assertTrue( isset( $result[0]['theme_supports']['disable-custom-gradients'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
+		$this->assertArrayHasKey( 'disable-custom-gradients', $result[0]['theme_supports'] );
 		$this->assertFalse( $result[0]['theme_supports']['disable-custom-gradients'] );
 	}
 
@@ -662,7 +663,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'disable-custom-gradients' );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertTrue( $result[0]['theme_supports']['disable-custom-gradients'] );
 	}
 
@@ -679,7 +680,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		add_theme_support( 'editor-gradient-presets', array( $gradient ) );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
-		$this->assertTrue( isset( $result[0]['theme_supports'] ) );
+		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertEquals( array( $gradient ), $result[0]['theme_supports']['editor-gradient-presets'] );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -392,7 +392,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_theme_supports_custom_header() {
 		remove_theme_support( 'custom-header' );
 		$wordpress_header = array(
-			'default-image'          => 'https://s.w.org/style/images/wporg-logo.svg',
+			'default-image'          => '',
 			'random-default'         => false,
 			'width'                  => 0,
 			'height'                 => 0,


### PR DESCRIPTION
https://core.trac.wordpress.org/attachment/ticket/49037

REST API: List all core theme feature support details in /themes endpoint response.

Fully list which first-party core theme features are supported in the /themes endpoint response. This brings the REST API themes controller's response more in line with the output of get_theme_support().

Props adamboro, apieschel, koke, spacedmonkey, TimothyBlynJacobs.
See #49037.