### PR TITLE
#49648: _fields parameter does not catch nested registered fields

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
@@ -451,7 +451,7 @@ abstract class WP_REST_Controller {
 				continue;
 			}
 
-			if ( ! in_array( $field_name, $requested_fields, true ) ) {
+			if ( ! rest_is_field_included( $field_name, $requested_fields ) ) {
 				continue;
 			}
 

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -561,6 +561,48 @@ class Tests_REST_API extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure inclusion of deeply nested fields may be controlled with request['_fields'].
+	 *
+	 * @ticket 49648
+	 */
+	public function test_rest_filter_response_fields_deeply_nested_field_filter() {
+		$response = new WP_REST_Response();
+
+		$response->set_data(
+			array(
+				'field' => array(
+					'a' => array(
+						'i' => 'value i',
+						'ii' => 'value ii',
+					),
+					'b' => array(
+						'iii' => 'value iii',
+						'iv' => 'value iv',
+					),
+				),
+			)
+		);
+		$request = array(
+			'_fields' => 'field.a.i,field.b.iv',
+		);
+
+		$response = rest_filter_response_fields( $response, null, $request );
+		$this->assertEquals(
+			array(
+				'field' => array(
+					'a' => array(
+						'i' => 'value i',
+					),
+					'b' => array(
+						'iv' => 'value iv',
+					),
+				),
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
 	 * Ensure that specifying a single top-level key in _fields includes that field and all children.
 	 *
 	 * @ticket 48266

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -572,12 +572,12 @@ class Tests_REST_API extends WP_UnitTestCase {
 			array(
 				'field' => array(
 					'a' => array(
-						'i' => 'value i',
+						'i'  => 'value i',
 						'ii' => 'value ii',
 					),
 					'b' => array(
 						'iii' => 'value iii',
-						'iv' => 'value iv',
+						'iv'  => 'value iv',
 					),
 				),
 			)

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -446,7 +446,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * @dataProvider data_filter_registered_rest_fields
+	 * @dataProvider data_filter_nested_registered_rest_fields
 	 * @ticket 49648
 	 */
 	public function test_filter_nested_registered_rest_fields( $filter, $expected ) {
@@ -472,7 +472,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 					),
 				),
 				'get_callback' => array( $this, 'register_nested_rest_field_get_callback' ),
-			),
+			)
 		);
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/testroute' );

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -454,7 +454,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 	 * @dataProvider data_filter_registered_rest_fields
 	 * @ticket 49648
 	 */
-	public function test_filter_registered_rest_fields( $filter, $expected ) {
+	public function test_filter_nested_registered_rest_fields( $filter, $expected ) {
 		$controller = new WP_REST_Test_Controller();
 
 		register_rest_field(
@@ -476,7 +476,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 						),
 					),
 				),
-				'get_callback' => array( $this, 'register_rest_field_get_callback' ),
+				'get_callback' => array( $this, 'register_nested_rest_field_get_callback' ),
 			),
 		);
 
@@ -484,6 +484,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$request->set_param( '_fields', $filter );
 
 		$response = $controller->prepare_item_for_response( array(), $request );
+		$response = rest_filter_response_fields( $response, rest_get_server(), $request );
 
 		$this->assertEquals( $expected, $response->get_data() );
 
@@ -491,7 +492,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$wp_rest_additional_fields = array();
 	}
 
-	public function register_rest_field_get_callback() {
+	public function register_nested_rest_field_get_callback() {
 		return array(
 			'a' => array(
 				'i' => 'value i',
@@ -504,7 +505,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		);
 	}
 
-	public function data_filter_registered_rest_fields() {
+	public function data_filter_nested_registered_rest_fields() {
 		return array(
 			array(
 				'field',

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -48,6 +48,13 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		);
 	}
 
+	public function tearDown() {
+		parent::tearDown();
+
+		global $wp_rest_additional_fields;
+		$wp_rest_additional_fields = array();
+	}
+
 	public function test_validate_schema_type_integer() {
 
 		$this->assertTrue(
@@ -309,9 +316,6 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$controller->prepare_item_for_response( array(), $request );
 
 		$this->assertGreaterThan( 0, $listener->get_call_count( $method ) );
-
-		global $wp_rest_additional_fields;
-		$wp_rest_additional_fields = array();
 	}
 
 	public function test_filtering_fields_for_response_by_context_returns_fields_with_no_context() {
@@ -340,9 +344,6 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$controller->prepare_item_for_response( array(), $request );
 
 		$this->assertGreaterThan( 0, $listener->get_call_count( $method ) );
-
-		global $wp_rest_additional_fields;
-		$wp_rest_additional_fields = array();
 	}
 
 	public function test_filtering_fields_for_response_by_context_returns_fields_with_no_schema() {
@@ -368,9 +369,6 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$controller->prepare_item_for_response( array(), $request );
 
 		$this->assertGreaterThan( 0, $listener->get_call_count( $method ) );
-
-		global $wp_rest_additional_fields;
-		$wp_rest_additional_fields = array();
 	}
 
 	/**
@@ -445,9 +443,6 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$controller->prepare_item_for_response( $item, $request );
 
 		$this->assertTrue( $listener->get_call_count( $method ) > $first_call_count );
-
-		global $wp_rest_additional_fields;
-		$wp_rest_additional_fields = array();
 	}
 
 	/**
@@ -461,7 +456,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 			'type',
 			'field',
 			array(
-				'schema' => array(
+				'schema'       => array(
 					'type'        => 'object',
 					'description' => 'A complex object',
 					'context'     => array( 'view', 'edit' ),
@@ -487,20 +482,17 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$response = rest_filter_response_fields( $response, rest_get_server(), $request );
 
 		$this->assertEquals( $expected, $response->get_data() );
-
-		global $wp_rest_additional_fields;
-		$wp_rest_additional_fields = array();
 	}
 
 	public function register_nested_rest_field_get_callback() {
 		return array(
 			'a' => array(
-				'i' => 'value i',
+				'i'  => 'value i',
 				'ii' => 'value ii',
 			),
 			'b' => array(
 				'iii' => 'value iii',
-				'iv' => 'value iv',
+				'iv'  => 'value iv',
 			),
 		);
 	}
@@ -512,12 +504,12 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 				array(
 					'field' => array(
 						'a' => array(
-							'i' => 'value i',
+							'i'  => 'value i',
 							'ii' => 'value ii',
 						),
 						'b' => array(
 							'iii' => 'value iii',
-							'iv' => 'value iv',
+							'iv'  => 'value iv',
 						),
 					),
 				),
@@ -527,7 +519,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 				array(
 					'field' => array(
 						'a' => array(
-							'i' => 'value i',
+							'i'  => 'value i',
 							'ii' => 'value ii',
 						),
 					),
@@ -539,7 +531,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 					'field' => array(
 						'b' => array(
 							'iii' => 'value iii',
-							'iv' => 'value iv',
+							'iv'  => 'value iv',
 						),
 					),
 				),
@@ -562,7 +554,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 				array(
 					'field' => array(
 						'a' => array(
-							'i' => 'value i',
+							'i'  => 'value i',
 							'ii' => 'value ii',
 						),
 						'b' => array(


### PR DESCRIPTION
[#49648: _fields parameter does not catch nested registered fields](https://core.trac.wordpress.org/ticket/49648)

REST API: Fix _fields filtering of registered rest fields.

Use rest_is_field_included when determining which additional fields to include to permit filtering by nested field properties.

Props Dudo, kadamwhite, TimothyBlynJacobs.
Fixes #49648.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
