### PR TITLE
55955: Fixing lint errors

### DIFF
--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -384,15 +384,17 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	public function test_feed_canonical_with_not_exists_query() {
 		// Set a NOT EXISTS tax_query on the global query.
 		$global_query = $GLOBALS['wp_query'];
-		$GLOBALS['wp_query'] = new WP_Query( array(
-			'post_type' => 'post',
-			'tax_query' => array(
-				array(
-					'taxonomy' => 'post_format',
-					'operator' => 'NOT EXISTS',
+		$GLOBALS['wp_query'] = new WP_Query(
+			array(
+				'post_type' => 'post',
+				'tax_query' => array(
+					array(
+						'taxonomy' => 'post_format',
+						'operator' => 'NOT EXISTS',
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		$url = redirect_canonical( get_term_feed_link( self::$terms['/category/parent/'] ), false );
 		$this->assertNull( $url );

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -383,7 +383,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	 */
 	public function test_feed_canonical_with_not_exists_query() {
 		// Set a NOT EXISTS tax_query on the global query.
-		$global_query = $GLOBALS['wp_query'];
+		$global_query        = $GLOBALS['wp_query'];
 		$GLOBALS['wp_query'] = new WP_Query(
 			array(
 				'post_type' => 'post',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR intends to fix the two lint errors reported by linter:
```
----------------------------------------------------------------------
 387 | ERROR | [x] Opening parenthesis of a multi-line function call
     |       |     must be the last content on the line
     |       |     (PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket)
 395 | ERROR | [x] Closing parenthesis of a multi-line function call
     |       |     must be on a line by itself
     |       |     (PEAR.Functions.FunctionCallSignature.CloseBracketLine)
----------------------------------------------------------------------
```

Trac ticket: https://core.trac.wordpress.org/ticket/55955

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
